### PR TITLE
Ivan: Implement Self-Feeding Learnings Capture in Expert Mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ariso-ai/ivan",
-  "version": "1.0.24",
+  "version": "1.0.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ariso-ai/ivan",
-      "version": "1.0.24",
+      "version": "1.0.28",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.8",

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,17 @@ interface Config {
   repoAllowedTools?: { [repoPath: string]: string[] };
   repoBlockedTools?: { [repoPath: string]: string[] };
   repoInstructionsDeclined?: { [repoPath: string]: boolean };
+  collaborative?: {
+    architectModel?: string;
+    maxDesignRounds?: number;
+    maxReviewRounds?: number;
+  };
+}
+
+export interface CollaborativeConfig {
+  architectModel: string;
+  maxDesignRounds: number;
+  maxReviewRounds: number;
 }
 
 export class ConfigManager {
@@ -703,6 +714,21 @@ export class ConfigManager {
   getClaudeModel(): string {
     const config = this.getConfig();
     return config?.claudeModel || 'claude-sonnet-4-6';
+  }
+
+  /**
+   * Settings for "expert" (collaborative) execution mode, where a separate
+   * architect Claude session critiques the implementer across design and review
+   * rounds. Defaults favor a strong reasoning model for the architect role.
+   */
+  getCollaborativeConfig(): CollaborativeConfig {
+    const config = this.getConfig();
+    const c = config?.collaborative;
+    return {
+      architectModel: c?.architectModel || 'claude-opus-4-8',
+      maxDesignRounds: c?.maxDesignRounds ?? 3,
+      maxReviewRounds: c?.maxReviewRounds ?? 2
+    };
   }
 
   async promptForExecutorType(): Promise<void> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,7 @@ interface Config {
     architectModel?: string;
     maxDesignRounds?: number;
     maxReviewRounds?: number;
+    captureLearnings?: boolean;
   };
 }
 
@@ -30,6 +31,7 @@ export interface CollaborativeConfig {
   architectModel: string;
   maxDesignRounds: number;
   maxReviewRounds: number;
+  captureLearnings: boolean;
 }
 
 export class ConfigManager {
@@ -727,7 +729,8 @@ export class ConfigManager {
     return {
       architectModel: c?.architectModel || 'claude-opus-4-8',
       maxDesignRounds: c?.maxDesignRounds ?? 3,
-      maxReviewRounds: c?.maxReviewRounds ?? 2
+      maxReviewRounds: c?.maxReviewRounds ?? 2,
+      captureLearnings: c?.captureLearnings ?? true
     };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,10 @@ import { TaskExecutor } from './services/task-executor.js';
 import { AddressExecutor } from './services/address-executor.js';
 import { DatabaseManager } from './database.js';
 import { WebServer } from './web-server.js';
-import type { NonInteractiveConfig } from './types/non-interactive-config.js';
+import type {
+  NonInteractiveConfig,
+  ExecutionMode
+} from './types/non-interactive-config.js';
 import { registerLearningsCommands } from './learnings/index.js';
 import {
   readFileSync,
@@ -36,6 +39,10 @@ program
   .option(
     '--rewrite-prompt',
     'Rewrite verbose task descriptions before execution using GPT-4o-mini'
+  )
+  .option(
+    '--mode <mode>',
+    'Execution mode: "simple" (one-shot hand-off, default) or "expert" (collaborative architect↔implementer loop informed by learnings)'
   );
 
 registerLearningsCommands(program);
@@ -655,12 +662,15 @@ async function runNonInteractive(configInput: string): Promise<void> {
     }
 
     // Apply --rewrite-prompt flag if passed on CLI
-    const { rewritePrompt, baseBranch } = program.opts<{
+    const { rewritePrompt, baseBranch, mode } = program.opts<{
       rewritePrompt: boolean;
       baseBranch?: string;
+      mode?: string;
     }>();
     if (rewritePrompt) config.rewritePrompt = true;
     if (baseBranch) config.baseBranch = baseBranch;
+    // CLI --mode overrides the config file; config value wins only if no flag.
+    if (mode !== undefined) config.mode = resolveMode(mode);
 
     // Validate config
     if (
@@ -709,16 +719,32 @@ async function runNonInteractive(configInput: string): Promise<void> {
   }
 }
 
+function resolveMode(raw: string | undefined): ExecutionMode {
+  const value = (raw || 'simple').toLowerCase();
+  if (value !== 'simple' && value !== 'expert') {
+    throw new Error(
+      `Invalid --mode "${raw}". Valid values are "simple" or "expert".`
+    );
+  }
+  return value;
+}
+
 async function main() {
   try {
     const args = process.argv.slice(2);
 
     // Parse known options early; operands are everything left after stripping flags
     const { operands } = program.parseOptions(args);
-    const { rewritePrompt: hasRewriteFlag, baseBranch } = program.opts<{
+    const {
+      rewritePrompt: hasRewriteFlag,
+      baseBranch,
+      mode: modeFlag
+    } = program.opts<{
       rewritePrompt: boolean;
       baseBranch?: string;
+      mode?: string;
     }>();
+    const mode = resolveMode(modeFlag);
 
     // Check for -c/--config flag
     const configFlagIndex = args.findIndex(
@@ -759,6 +785,7 @@ async function main() {
       const config: NonInteractiveConfig = {
         tasks: [taskDescription],
         rewritePrompt: hasRewriteFlag,
+        mode,
         ...(baseBranch && { baseBranch })
       };
 
@@ -807,7 +834,7 @@ async function main() {
       await runMigrations();
 
       const taskExecutor = new TaskExecutor();
-      await taskExecutor.executeWorkflow(hasRewriteFlag, baseBranch);
+      await taskExecutor.executeWorkflow(hasRewriteFlag, baseBranch, mode);
       return;
     }
 

--- a/src/learnings/critique-distiller.ts
+++ b/src/learnings/critique-distiller.ts
@@ -1,0 +1,268 @@
+// Converts architect review critiques from expert mode into actionable learning records.
+// This distiller mirrors the extraction pipeline pattern from extractor.ts but focuses on
+// collaborative review feedback rather than GitHub PR discourse.
+
+import OpenAI from 'openai';
+import { rebuildLearningsDatabase } from './builder.js';
+import { createDeterministicId } from './id.js';
+import { writeLearningRecords } from './learning-writer.js';
+import { LESSONS_JSONL_RELATIVE_PATH } from './paths.js';
+import type { LearningRecord } from './record-types.js';
+import {
+  ensureLearningsDirectories,
+  resolveLearningsRepositoryContext
+} from './repository.js';
+import { loadCanonicalRecords } from './parser.js';
+
+/**
+ * JSON Schema passed to OpenAI structured outputs (strict: true).
+ * The model is constrained to emit exactly this shape.
+ * Returns 0..N lessons per critique (not 1:1).
+ */
+const DISTILLATION_SCHEMA = {
+  type: 'object',
+  properties: {
+    items: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          lessons: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                statement: { type: 'string' },
+                kind: {
+                  type: 'string',
+                  enum: ['repo_convention', 'engineering_lesson']
+                },
+                confidence: { type: 'number' },
+                rationale: { anyOf: [{ type: 'null' }, { type: 'string' }] },
+                applicability: {
+                  anyOf: [{ type: 'null' }, { type: 'string' }]
+                }
+              },
+              required: [
+                'statement',
+                'kind',
+                'confidence',
+                'rationale',
+                'applicability'
+              ],
+              additionalProperties: false
+            }
+          }
+        },
+        required: ['lessons'],
+        additionalProperties: false
+      }
+    }
+  },
+  required: ['items'],
+  additionalProperties: false
+} as const;
+
+interface LessonOutput {
+  statement: string;
+  kind: 'repo_convention' | 'engineering_lesson';
+  confidence: number;
+  rationale: string | null;
+  applicability: string | null;
+}
+
+interface LessonItem {
+  lessons: LessonOutput[];
+}
+
+interface DistillationResponse {
+  items: LessonItem[];
+}
+
+const DISTILLATION_SYSTEM_PROMPT = `\
+You are an expert at extracting actionable engineering lessons from architect review feedback in a collaborative development process.
+
+For each critique, determine if it contains reusable engineering lessons worth preserving as institutional knowledge. A single critique often contains MULTIPLE distinct lessons — extract ALL of them.
+
+If a critique contains no generalizable lessons (task-specific or one-off feedback), return an empty lessons array for that critique.
+
+## Rewriting guidelines
+
+Transform architect feedback into clear imperatives:
+
+| Input pattern                                        | Output form                       |
+|------------------------------------------------------|-----------------------------------|
+| "I think X would be nice [as we Y]"                  | "Consider X [as we Y]"            |
+| "I recommend X" / "I'd recommend X"                  | X                                 |
+| "This should X" / "We should X"                      | X                                 |
+| "Can we X?" / "Could we X?"                          | X                                 |
+| "Needs to X" / "Need to X"                           | X                                 |
+| "avoid X" / "prefer X" / "use X" / "ensure X"       | keep as-is (already imperative)   |
+| "This doesn't X, we need Y"                          | Y                                 |
+| "Missing X" / "Lacks X"                              | "Include X" / "Add X"             |
+
+Write statements in sentence case (capitalize the first word only).
+Ignore "VERDICT: APPROVE" or "VERDICT: REVISE" lines if present — these are markers, not lessons.
+
+## Return empty lessons array for
+
+- Task-specific implementation details: "Fix the login bug", "Add error handling to processPayment()"
+- Single-file or single-function critiques without broader applicability
+- Pure questions without extractable answers
+- Stylistic nitpicks without architectural significance
+- One-off corrections specific to this task
+
+## Classification (kind)
+
+"repo_convention" -- statement references project-specific tools or patterns:
+  ivan, claude, hook, prompt, CLI, command, settings, GitHub workflow, worktree, specific file/directory names
+
+"engineering_lesson" -- general software engineering patterns applicable beyond this repo.
+
+## Confidence
+
+These are single-source critiques (architect only, not validated by merge/approval), so confidence should be LOWER than multi-source PR learnings.
+
+Derive from generalizability and certainty; target the [0.35, 0.75] range:
+  - Broadly applicable architectural patterns, high certainty: 0.65-0.75
+  - Specific but reusable patterns, medium certainty: 0.50-0.65
+  - Narrowly applicable or uncertain guidance: 0.35-0.50
+
+Return one item per critique in the same order as the input.
+Set lessons to an empty array when the critique contains no reusable lessons.
+Set rationale and applicability to null when not applicable.`;
+
+/**
+ * Distills architect critiques into learning records.
+ * Holds the OpenAI client as an instance field, matching the codebase's class-based service pattern.
+ */
+export class CritiqueDistiller {
+  private client: OpenAI | null = null;
+
+  private getClient(): OpenAI {
+    if (!this.client) this.client = new OpenAI();
+    return this.client;
+  }
+
+  /**
+   * Distills critiques into learning records via LLM and returns them.
+   * Does not persist; caller is responsible for storage.
+   */
+  async distillCritiques(critiques: string[]): Promise<LearningRecord[]> {
+    if (critiques.length === 0) return [];
+
+    const userContent = critiques
+      .map((critique, i) => {
+        const cleaned = critique
+          .replace(/VERDICT:\s*(APPROVE|APPROVED|REVISE)\s*$/im, '')
+          .trim();
+        return [`## Critique ${i + 1}`, '', cleaned].join('\n');
+      })
+      .join('\n\n---\n\n');
+
+    const response = await this.getClient().chat.completions.create({
+      model: 'gpt-4o-mini',
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'critique_distillation',
+          strict: true,
+          schema: DISTILLATION_SCHEMA
+        }
+      },
+      messages: [
+        { role: 'system', content: DISTILLATION_SYSTEM_PROMPT },
+        { role: 'user', content: userContent }
+      ]
+    });
+
+    let distillation: DistillationResponse;
+    try {
+      distillation = JSON.parse(
+        response.choices[0]?.message?.content ?? '{"items":[]}'
+      ) as DistillationResponse;
+    } catch {
+      return [];
+    }
+
+    const now = new Date().toISOString();
+    const results: LearningRecord[] = [];
+
+    // Flatten: extract all lessons from all critiques
+    for (const item of distillation.items) {
+      for (const lesson of item.lessons) {
+        const { statement, kind, confidence, rationale, applicability } =
+          lesson;
+        const trimmed = statement.trim();
+        if (trimmed.length < 4) continue;
+
+        results.push({
+          type: 'learning',
+          sourcePath: LESSONS_JSONL_RELATIVE_PATH,
+          id: createDeterministicId('lrn', 'collab', trimmed),
+          kind,
+          source_type: 'collaborative_review',
+          statement: trimmed,
+          title:
+            trimmed.length <= 72
+              ? trimmed
+              : `${trimmed.slice(0, 69).trimEnd()}...`,
+          ...(rationale !== null ? { rationale } : {}),
+          ...(applicability !== null ? { applicability } : {}),
+          confidence: Math.max(0.35, Math.min(0.75, confidence)),
+          status: 'active',
+          created_at: now,
+          updated_at: now
+        });
+      }
+    }
+
+    return results;
+  }
+}
+
+// Module-level shared instance used by the standalone helper function below.
+const _sharedDistiller = new CritiqueDistiller();
+
+/**
+ * Best-effort capture of architect critiques as learning records.
+ * Distills design and review critiques, merges with existing learnings, and rebuilds the database.
+ * Wrapped in try/catch by the caller; any error should be logged but not fail the task.
+ */
+export async function captureLearnings(
+  repoPath: string,
+  designCritiques: string[],
+  reviewCritiques: string[]
+): Promise<void> {
+  const allCritiques = [...designCritiques, ...reviewCritiques];
+  if (allCritiques.length === 0) return;
+
+  const context = resolveLearningsRepositoryContext(repoPath);
+  ensureLearningsDirectories(context);
+
+  const newRecords = await _sharedDistiller.distillCritiques(allCritiques);
+  if (newRecords.length === 0) return;
+
+  // Merge pattern from coding-sessions-command.ts:205-219
+  const newRecordIds = new Set(newRecords.map((r) => r.id));
+  const dataset = loadCanonicalRecords(repoPath);
+  const existingRecords = dataset.learnings.filter(
+    (r) => !newRecordIds.has(r.id)
+  );
+  const mergedRecords = [...existingRecords, ...newRecords];
+
+  writeLearningRecords(repoPath, mergedRecords);
+  await rebuildLearningsDatabase(repoPath);
+
+  // Note: rebuildLearningsDatabase performs network calls (embedTexts → OpenAI) to generate
+  // embeddings for any new/changed records, and rewrites lessons.jsonl with the cached vectors
+  // (builder.ts:237 writeBackEmbeddings). This happens synchronously at the end of every
+  // expert-mode task that triggers revisions. The rebuild is required to make new learnings
+  // queryable immediately; without it, they sit in JSONL but won't appear in queryLearnings
+  // results until something else triggers a rebuild (which may never happen in a worktree flow).
+  //
+  // Concurrent expert-mode tasks on the same main repo could interleave JSONL writes (no locking).
+  // This is an accepted risk across the entire learnings pipeline (extractor.ts, coding-sessions,
+  // etc. all have the same exposure). The best-effort try/catch in collaborative-executor.ts
+  // ensures failures here never block task completion.
+}

--- a/src/services/claude-cli-executor.ts
+++ b/src/services/claude-cli-executor.ts
@@ -3,7 +3,11 @@ import chalk from 'chalk';
 import { ConfigManager } from '../config.js';
 import path from 'path';
 import { execSync } from 'child_process';
-import type { IClaudeExecutor } from './executor-factory.js';
+import type {
+  IClaudeExecutor,
+  TurnOptions,
+  TurnResult
+} from './executor-factory.js';
 
 export class ClaudeCliExecutor implements IClaudeExecutor {
   public quietMode: boolean = false;
@@ -26,7 +30,26 @@ export class ClaudeCliExecutor implements IClaudeExecutor {
     taskDescription: string,
     workingDir: string,
     sessionId?: string
-  ): Promise<{ log: string; lastMessage: string; sessionId: string }> {
+  ): Promise<TurnResult> {
+    return this.executeTurn(taskDescription, workingDir, {
+      sessionId,
+      permissionMode: 'bypassPermissions'
+    });
+  }
+
+  async executeTurn(
+    taskDescription: string,
+    workingDir: string,
+    options: TurnOptions = {}
+  ): Promise<TurnResult> {
+    const {
+      sessionId,
+      permissionMode = 'bypassPermissions',
+      systemPrompt,
+      model: modelOverride,
+      readOnly = false
+    } = options;
+
     console.log(
       chalk.blue(`🤖 Executing task with Claude Code CLI: ${taskDescription}`)
     );
@@ -69,8 +92,13 @@ export class ClaudeCliExecutor implements IClaudeExecutor {
       const blockedTools =
         await this.configManager.getRepoBlockedTools(originalRepoPath);
 
-      // Always block EnterPlanMode and AskUserQuestion globally
-      const globallyBlockedTools = ['EnterPlanMode', 'AskUserQuestion'];
+      // Always block EnterPlanMode and AskUserQuestion globally. In read-only
+      // (architect) turns, also block file-mutating tools.
+      const globallyBlockedTools = [
+        'EnterPlanMode',
+        'AskUserQuestion',
+        ...(readOnly ? ['Edit', 'Write', 'NotebookEdit'] : [])
+      ];
 
       // Combine globally blocked tools with repository-specific blocked tools
       const allBlockedTools = blockedTools
@@ -113,8 +141,8 @@ export class ClaudeCliExecutor implements IClaudeExecutor {
         }
       }
 
-      // Get the selected model
-      const model = this.configManager.getClaudeModel();
+      // Get the selected model (architect turns may override it)
+      const model = modelOverride || this.configManager.getClaudeModel();
 
       console.log(chalk.gray(`Working directory: ${workingDir}`));
       console.log(chalk.gray(`Model: ${model}`));
@@ -134,8 +162,13 @@ export class ClaudeCliExecutor implements IClaudeExecutor {
         '--model',
         model,
         '--permission-mode',
-        'bypassPermissions'
+        permissionMode
       ];
+
+      // Add an architect/reviewer persona or other per-turn system prompt
+      if (systemPrompt) {
+        args.push('--append-system-prompt', systemPrompt);
+      }
 
       // Add allowed tools if specified
       if (

--- a/src/services/claude-executor.ts
+++ b/src/services/claude-executor.ts
@@ -3,7 +3,11 @@ import chalk from 'chalk';
 import { ConfigManager } from '../config.js';
 import path from 'path';
 import { execSync } from 'child_process';
-import type { IClaudeExecutor } from './executor-factory.js';
+import type {
+  IClaudeExecutor,
+  TurnOptions,
+  TurnResult
+} from './executor-factory.js';
 
 export class ClaudeExecutor implements IClaudeExecutor {
   public quietMode: boolean = false;
@@ -33,7 +37,26 @@ export class ClaudeExecutor implements IClaudeExecutor {
     taskDescription: string,
     workingDir: string,
     sessionId?: string
-  ): Promise<{ log: string; lastMessage: string; sessionId: string }> {
+  ): Promise<TurnResult> {
+    return this.executeTurn(taskDescription, workingDir, {
+      sessionId,
+      permissionMode: 'bypassPermissions'
+    });
+  }
+
+  async executeTurn(
+    taskDescription: string,
+    workingDir: string,
+    options: TurnOptions = {}
+  ): Promise<TurnResult> {
+    const {
+      sessionId,
+      permissionMode = 'bypassPermissions',
+      systemPrompt,
+      model: modelOverride,
+      readOnly = false
+    } = options;
+
     if (!this.quietMode) {
       console.log(
         chalk.blue(`🤖 Executing task with Claude Code: ${taskDescription}`)
@@ -74,8 +97,14 @@ export class ClaudeExecutor implements IClaudeExecutor {
       const blockedTools =
         await this.configManager.getRepoBlockedTools(originalRepoPath);
 
-      // Always block EnterPlanMode and AskUserQuestion globally
-      const globallyBlockedTools = ['EnterPlanMode', 'AskUserQuestion'];
+      // Always block EnterPlanMode and AskUserQuestion globally. In read-only
+      // (architect) turns, also block file-mutating tools so the reviewer can
+      // inspect the worktree without changing it.
+      const globallyBlockedTools = [
+        'EnterPlanMode',
+        'AskUserQuestion',
+        ...(readOnly ? ['Edit', 'Write', 'NotebookEdit'] : [])
+      ];
 
       // Combine globally blocked tools with repository-specific blocked tools
       const allBlockedTools = blockedTools
@@ -118,8 +147,8 @@ export class ClaudeExecutor implements IClaudeExecutor {
         }
       }
 
-      // Get the selected model
-      const model = this.configManager.getClaudeModel();
+      // Get the selected model (architect turns may override it)
+      const model = modelOverride || this.configManager.getClaudeModel();
 
       if (!this.quietMode) {
         console.log(chalk.gray(`Working directory: ${workingDir}`));
@@ -160,9 +189,10 @@ export class ClaudeExecutor implements IClaudeExecutor {
             // 2) (Optional) If you sometimes hop folders, explicitly whitelist them:
             additionalDirectories: [workingDir],
 
-            // 3) Allow edit tools in headless mode:
-            //    Use 'acceptEdits' for safer default; 'bypassPermissions' is most permissive.
-            permissionMode: 'bypassPermissions',
+            // 3) Permission mode: 'plan' for design dialogue (no edits),
+            //    'bypassPermissions' for implementation turns.
+            permissionMode,
+            ...(systemPrompt !== undefined && { systemPrompt }),
             ...(allowedTools !== undefined && { allowedTools }),
             disallowedTools: allBlockedTools,
             model: model,

--- a/src/services/collaborative-executor.ts
+++ b/src/services/collaborative-executor.ts
@@ -1,11 +1,9 @@
 import chalk from 'chalk';
-import type {
-  IClaudeExecutor,
-  TurnResult
-} from './executor-factory.js';
+import type { IClaudeExecutor, TurnResult } from './executor-factory.js';
 import type { CollaborativeConfig } from '../config.js';
 import { queryLearnings } from '../learnings/index.js';
 import type { LearningsQueryResult } from '../learnings/types.js';
+import { captureLearnings } from '../learnings/critique-distiller.js';
 
 /**
  * The architect persona. A separate Claude session adopts this role to critique
@@ -72,6 +70,10 @@ export class CollaborativeExecutor {
       transcript.push(`\n=== ${heading} ===\n${body}`);
     };
 
+    // Collect architect critiques that triggered revisions for later learning capture
+    const designCritiques: string[] = [];
+    const reviewCritiques: string[] = [];
+
     this.header('🧠 Expert mode: assembling institutional knowledge');
     const brief = await this.buildBrief(learningsRepoPath, taskDescription);
     if (brief) {
@@ -125,6 +127,9 @@ export class CollaborativeExecutor {
         );
         break;
       }
+
+      // Collect this critique for later learning capture
+      designCritiques.push(verdict.notes);
 
       this.header(`🔨 Implementer — revising plan (round ${round})`);
       plan = await this.turn(
@@ -185,6 +190,9 @@ export class CollaborativeExecutor {
         break;
       }
 
+      // Collect this critique for later learning capture
+      reviewCritiques.push(verdict.notes);
+
       this.header(`🔨 Implementer — applying review changes (round ${round})`);
       const revisionLog = await this.turn(
         this.reviseCodePrompt(verdict.notes),
@@ -193,6 +201,28 @@ export class CollaborativeExecutor {
         (r) => (implSession = r.sessionId)
       );
       record(`Implementer — revisions (round ${round})`, revisionLog);
+    }
+
+    // Best-effort capture of architect critiques as learnings
+    if (
+      this.config.captureLearnings &&
+      (designCritiques.length > 0 || reviewCritiques.length > 0)
+    ) {
+      try {
+        await captureLearnings(
+          learningsRepoPath,
+          designCritiques,
+          reviewCritiques
+        );
+        console.log(
+          chalk.gray(
+            `📚 Captured ${designCritiques.length + reviewCritiques.length} critique(s) as learnings`
+          )
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.log(chalk.gray(`Learnings capture skipped: ${msg}`));
+      }
     }
 
     return {

--- a/src/services/collaborative-executor.ts
+++ b/src/services/collaborative-executor.ts
@@ -1,0 +1,339 @@
+import chalk from 'chalk';
+import type {
+  IClaudeExecutor,
+  TurnResult
+} from './executor-factory.js';
+import type { CollaborativeConfig } from '../config.js';
+import { queryLearnings } from '../learnings/index.js';
+import type { LearningsQueryResult } from '../learnings/types.js';
+
+/**
+ * The architect persona. A separate Claude session adopts this role to critique
+ * the implementer across design and review rounds — Ivan acting as a principal
+ * engineer / critical-thinking partner rather than a one-shot dispatcher.
+ */
+const ARCHITECT_SYSTEM_PROMPT = `You are a principal engineer reviewing a teammate's work. You hold your team's hard-won institutional knowledge and you care about correctness, simplicity, and long-term maintainability.
+
+You are not the implementer — you do not write the code. Your job is to think critically: challenge questionable decisions, surface risks and edge cases, point out where the work diverges from the team's established lessons, and propose simpler or safer alternatives. Be specific and concrete; vague approval is worse than useless. You may read and inspect the codebase, but never modify it.
+
+When you finish, end your message with exactly one line, nothing after it:
+VERDICT: APPROVE
+or
+VERDICT: REVISE`;
+
+const MAX_DIFF_CHARS = 60000;
+
+export interface CollaborativeRunParams {
+  /** The task to accomplish (already including any repo-specific instructions). */
+  taskDescription: string;
+  /** The worktree path where the implementer should edit and the architect inspects. */
+  executionPath: string;
+  /**
+   * The main repository path (where `.ivan/` lives). Used to query learnings,
+   * since the worktree does not contain the learnings store.
+   */
+  learningsRepoPath: string;
+  /** Returns the current working-tree diff for the review phase. */
+  getDiff: () => string;
+  /** Optional session to resume so multi-task / single-PR runs keep context. */
+  incomingSessionId?: string;
+}
+
+interface Verdict {
+  approve: boolean;
+  /** The architect's full message, fed back to the implementer when revising. */
+  notes: string;
+}
+
+/**
+ * Drives an "expert"-mode collaboration: a separate architect Claude session
+ * critiques an implementer Claude session across a design dialogue, then the
+ * implementation, then a code-review dialogue — informed by the team's
+ * institutional learnings. The implementer's final session is returned so
+ * callers can thread context across tasks (single-PR mode).
+ */
+export class CollaborativeExecutor {
+  constructor(
+    private executor: IClaudeExecutor,
+    private config: CollaborativeConfig
+  ) {}
+
+  async run(params: CollaborativeRunParams): Promise<TurnResult> {
+    const {
+      taskDescription,
+      executionPath,
+      learningsRepoPath,
+      getDiff,
+      incomingSessionId
+    } = params;
+
+    const transcript: string[] = [];
+    const record = (heading: string, body: string) => {
+      transcript.push(`\n=== ${heading} ===\n${body}`);
+    };
+
+    this.header('🧠 Expert mode: assembling institutional knowledge');
+    const brief = await this.buildBrief(learningsRepoPath, taskDescription);
+    if (brief) {
+      console.log(chalk.gray(brief));
+      record('Institutional knowledge', brief);
+    } else {
+      console.log(
+        chalk.gray('No relevant learnings found — proceeding without a brief.')
+      );
+    }
+
+    let implSession = incomingSessionId;
+    let architectSession: string | undefined;
+
+    // ----- Phase 1: design dialogue -----
+    this.header('📐 Design dialogue');
+    let plan = await this.turn(
+      this.planPrompt(taskDescription, brief),
+      executionPath,
+      { sessionId: implSession, permissionMode: 'plan' },
+      (r) => (implSession = r.sessionId)
+    );
+    record('Implementer — proposed plan', plan);
+
+    for (let round = 1; round <= this.config.maxDesignRounds; round++) {
+      this.header(`🏛️  Architect — design review (round ${round})`);
+      const review = await this.turn(
+        this.designReviewPrompt(taskDescription, plan, brief),
+        executionPath,
+        {
+          sessionId: architectSession,
+          permissionMode: 'plan',
+          readOnly: true,
+          systemPrompt: ARCHITECT_SYSTEM_PROMPT,
+          model: this.config.architectModel
+        },
+        (r) => (architectSession = r.sessionId)
+      );
+      const verdict = this.parseVerdict(review);
+      record(`Architect — design review (round ${round})`, review);
+
+      if (verdict.approve) {
+        console.log(chalk.green('✅ Architect approved the design.'));
+        break;
+      }
+      if (round === this.config.maxDesignRounds) {
+        console.log(
+          chalk.yellow(
+            '⚠️  Design rounds exhausted; proceeding with the latest plan.'
+          )
+        );
+        break;
+      }
+
+      this.header(`🔨 Implementer — revising plan (round ${round})`);
+      plan = await this.turn(
+        this.revisePlanPrompt(verdict.notes),
+        executionPath,
+        { sessionId: implSession, permissionMode: 'plan' },
+        (r) => (implSession = r.sessionId)
+      );
+      record(`Implementer — revised plan (round ${round})`, plan);
+    }
+
+    // ----- Phase 2: implementation -----
+    this.header('🛠️  Implementation');
+    const implLog = await this.turn(
+      this.implementPrompt(),
+      executionPath,
+      { sessionId: implSession, permissionMode: 'bypassPermissions' },
+      (r) => (implSession = r.sessionId)
+    );
+    record('Implementer — implementation', implLog);
+
+    // ----- Phase 3: code-review dialogue -----
+    for (let round = 1; round <= this.config.maxReviewRounds; round++) {
+      const diff = this.truncateDiff(getDiff());
+      if (!diff.trim()) {
+        console.log(
+          chalk.yellow('⚠️  No changes to review; skipping code review.')
+        );
+        break;
+      }
+
+      this.header(`🏛️  Architect — code review (round ${round})`);
+      const review = await this.turn(
+        this.codeReviewPrompt(taskDescription, plan, diff, brief),
+        executionPath,
+        {
+          sessionId: architectSession,
+          permissionMode: 'plan',
+          readOnly: true,
+          systemPrompt: ARCHITECT_SYSTEM_PROMPT,
+          model: this.config.architectModel
+        },
+        (r) => (architectSession = r.sessionId)
+      );
+      const verdict = this.parseVerdict(review);
+      record(`Architect — code review (round ${round})`, review);
+
+      if (verdict.approve) {
+        console.log(chalk.green('✅ Architect approved the implementation.'));
+        break;
+      }
+      if (round === this.config.maxReviewRounds) {
+        console.log(
+          chalk.yellow(
+            '⚠️  Review rounds exhausted; proceeding with the current implementation.'
+          )
+        );
+        break;
+      }
+
+      this.header(`🔨 Implementer — applying review changes (round ${round})`);
+      const revisionLog = await this.turn(
+        this.reviseCodePrompt(verdict.notes),
+        executionPath,
+        { sessionId: implSession, permissionMode: 'bypassPermissions' },
+        (r) => (implSession = r.sessionId)
+      );
+      record(`Implementer — revisions (round ${round})`, revisionLog);
+    }
+
+    return {
+      log: transcript.join('\n'),
+      lastMessage: implLog,
+      sessionId: implSession || ''
+    };
+  }
+
+  /**
+   * Runs a turn, captures its session id via the callback, and returns the
+   * full output text. We use `log` (the complete transcript) rather than
+   * `lastMessage` because the CLI executor only captures the last stdout line
+   * there, which would truncate the architect's critique and verdict.
+   */
+  private async turn(
+    prompt: string,
+    executionPath: string,
+    options: Parameters<IClaudeExecutor['executeTurn']>[2],
+    onResult: (r: TurnResult) => void
+  ): Promise<string> {
+    const r = await this.executor.executeTurn(prompt, executionPath, options);
+    onResult(r);
+    return r.log?.trim() || r.lastMessage;
+  }
+
+  private async buildBrief(
+    learningsRepoPath: string,
+    taskDescription: string
+  ): Promise<string> {
+    let learnings: LearningsQueryResult[] = [];
+    try {
+      learnings = await queryLearnings(learningsRepoPath, taskDescription, {
+        limit: 8
+      });
+    } catch {
+      // No learnings store, or it failed to open — expert mode still works.
+      return '';
+    }
+    if (learnings.length === 0) return '';
+
+    return learnings
+      .map((l) => {
+        const label = l.title || l.kind;
+        const parts = [`- [${label}] ${l.statement}`];
+        if (l.rationale) parts.push(`  Why: ${l.rationale}`);
+        if (l.applicability) parts.push(`  When: ${l.applicability}`);
+        if (l.source_url) parts.push(`  Source: ${l.source_url}`);
+        return parts.join('\n');
+      })
+      .join('\n');
+  }
+
+  private parseVerdict(message: string): Verdict {
+    const match = message.match(/VERDICT:\s*(APPROVE|APPROVED|REVISE)/i);
+    // Default to approve when no explicit verdict is found, to avoid burning
+    // rounds on an ambiguous response.
+    const approve = match ? /APPROVE/i.test(match[1]) : true;
+    return { approve, notes: message };
+  }
+
+  private truncateDiff(diff: string): string {
+    if (diff.length <= MAX_DIFF_CHARS) return diff;
+    return (
+      diff.slice(0, MAX_DIFF_CHARS) +
+      `\n\n[... diff truncated at ${MAX_DIFF_CHARS} characters. Read the files directly to review the rest. ...]`
+    );
+  }
+
+  private header(text: string): void {
+    console.log('');
+    console.log(chalk.magenta.bold(text));
+  }
+
+  // ----- Prompt builders -----
+
+  private briefBlock(brief: string): string {
+    return brief
+      ? `\nRelevant institutional knowledge (lessons from this team's past PRs and coding sessions — weigh these heavily):\n${brief}\n`
+      : '';
+  }
+
+  private planPrompt(task: string, brief: string): string {
+    return `${task}
+${this.briefBlock(brief)}
+Before writing any code, think like you're pairing with a senior engineer. Produce a concise technical plan: your intended approach, the key files you'll touch, the edge cases you'll handle, and any risks or trade-offs. Do NOT implement anything yet — respond with the plan only.`;
+  }
+
+  private designReviewPrompt(
+    task: string,
+    plan: string,
+    brief: string
+  ): string {
+    return `Review a teammate's PROPOSED PLAN for the following task. No code has been written yet.
+
+TASK:
+${task}
+${this.briefBlock(brief)}
+PROPOSED PLAN:
+${plan}
+
+Scrutinize the plan. Inspect the codebase (read-only) as needed to ground your critique. Look for: a wrong or over-complicated approach, missed edge cases, anything that violates the institutional knowledge above, unaddressed risks, and simpler alternatives.`;
+  }
+
+  private revisePlanPrompt(notes: string): string {
+    return `Your reviewer (a principal engineer) raised the following on your plan:
+
+${notes}
+
+Revise your technical plan to address this feedback. Do NOT implement yet — respond with the updated plan only.`;
+  }
+
+  private implementPrompt(): string {
+    return `Your plan has been approved by the reviewer. Implement it in full now. Follow the agreed approach and honor the institutional knowledge discussed earlier.`;
+  }
+
+  private codeReviewPrompt(
+    task: string,
+    plan: string,
+    diff: string,
+    brief: string
+  ): string {
+    return `Review your teammate's IMPLEMENTATION (the diff below) for this task.
+
+TASK:
+${task}
+
+AGREED PLAN:
+${plan}
+${this.briefBlock(brief)}
+DIFF:
+${diff}
+
+Review for correctness bugs, deviations from the agreed plan, violations of the institutional knowledge, missing tests or edge cases, and simplification opportunities. You may inspect the codebase read-only.`;
+  }
+
+  private reviseCodePrompt(notes: string): string {
+    return `Your reviewer (a principal engineer) requested changes:
+
+${notes}
+
+Apply these changes to the implementation now.`;
+  }
+}

--- a/src/services/executor-factory.ts
+++ b/src/services/executor-factory.ts
@@ -2,13 +2,46 @@ import { ClaudeExecutor } from './claude-executor.js';
 import { ClaudeCliExecutor } from './claude-cli-executor.js';
 import { ConfigManager } from '../config.js';
 
+export interface TurnResult {
+  log: string;
+  lastMessage: string;
+  sessionId: string;
+}
+
+export interface TurnOptions {
+  /** Resume an existing Claude session to preserve conversational context. */
+  sessionId?: string;
+  /** Permission mode for this turn. 'plan' prevents edits (design dialogue). */
+  permissionMode?: 'plan' | 'acceptEdits' | 'bypassPermissions';
+  /** Optional system prompt to shape the turn (e.g. the architect persona). */
+  systemPrompt?: string;
+  /** Override the configured model for this turn (e.g. the architect model). */
+  model?: string;
+  /**
+   * When true, disallow file-mutating tools (Edit/Write/NotebookEdit) so the
+   * session can read, grep, and inspect but not modify the worktree. Used for
+   * the architect/reviewer role.
+   */
+  readOnly?: boolean;
+}
+
 export interface IClaudeExecutor {
   quietMode: boolean;
   executeTask(
     taskDescription: string,
     workingDir: string,
     sessionId?: string
-  ): Promise<{ log: string; lastMessage: string; sessionId: string }>;
+  ): Promise<TurnResult>;
+  /**
+   * Execute a single conversational turn with fine-grained control over
+   * session continuity, permission mode, system prompt, model, and tool access.
+   * `executeTask` is a thin wrapper over this with implementer defaults.
+   */
+  executeTurn(
+    prompt: string,
+    workingDir: string,
+    options?: TurnOptions
+  ): Promise<TurnResult>;
   generateTaskBreakdown(
     jobDescription: string,
     workingDir: string

--- a/src/services/task-executor.ts
+++ b/src/services/task-executor.ts
@@ -19,6 +19,9 @@ import {
   createRepositoryManager
 } from './service-factory.js';
 import { PromptRewriter } from './prompt-rewriter.js';
+import { CollaborativeExecutor } from './collaborative-executor.js';
+import type { ExecutionMode } from '../types/non-interactive-config.js';
+import type { TurnResult } from './executor-factory.js';
 
 export class TaskExecutor {
   private jobManager: JobManager;
@@ -30,6 +33,7 @@ export class TaskExecutor {
   private workingDir: string;
   private repoInstructions: string | undefined;
   private baseBranch: string | undefined;
+  private executionMode: ExecutionMode;
 
   constructor() {
     this.jobManager = new JobManager();
@@ -38,6 +42,42 @@ export class TaskExecutor {
     this.workingDir = '';
     this.repoInstructions = undefined;
     this.baseBranch = undefined;
+    this.executionMode = 'simple';
+  }
+
+  /**
+   * Runs the implementation for a task, branching on execution mode:
+   * - 'simple': a single one-shot hand-off to Claude Code (default)
+   * - 'expert': a collaborative architect↔implementer loop informed by learnings
+   */
+  private async runImplementation(
+    taskWithInstructions: string,
+    executionPath: string,
+    sessionId?: string
+  ): Promise<TurnResult> {
+    if (this.executionMode === 'expert') {
+      const collaborative = new CollaborativeExecutor(
+        this.getClaudeExecutor(),
+        this.configManager.getCollaborativeConfig()
+      );
+      return collaborative.run({
+        taskDescription: taskWithInstructions,
+        executionPath,
+        learningsRepoPath: this.workingDir,
+        getDiff: () => {
+          if (!this.gitManager) {
+            throw new Error('GitManager not initialized');
+          }
+          return this.gitManager.getDiff();
+        },
+        incomingSessionId: sessionId
+      });
+    }
+    return this.getClaudeExecutor().executeTask(
+      taskWithInstructions,
+      executionPath,
+      sessionId
+    );
   }
 
   private getClaudeExecutor(): IClaudeExecutor {
@@ -56,10 +96,21 @@ export class TaskExecutor {
 
   async executeWorkflow(
     rewritePrompt: boolean = false,
-    baseBranch?: string
+    baseBranch?: string,
+    mode: ExecutionMode = 'simple'
   ): Promise<void> {
     try {
       this.baseBranch = baseBranch?.trim() || undefined;
+      this.executionMode = mode;
+
+      if (mode === 'expert') {
+        console.log(
+          chalk.magenta.bold(
+            '🧠 Expert mode: Ivan will act as a principal engineer, ' +
+              'critiquing the design and implementation across rounds.'
+          )
+        );
+      }
 
       console.log(chalk.blue.bold('🚀 Starting Ivan workflow'));
       console.log('');
@@ -428,7 +479,7 @@ export class TaskExecutor {
 
       // Use worktree path for Claude execution, falling back to workingDir if needed
       const executionPath = worktreePath || this.workingDir;
-      const result = await this.getClaudeExecutor().executeTask(
+      const result = await this.runImplementation(
         taskWithInstructions,
         executionPath
       );
@@ -731,7 +782,7 @@ export class TaskExecutor {
         // Use worktree path for Claude execution
         const executionPath = worktreePath || this.workingDir;
         // Pass session ID to maintain context between tasks
-        const result = await this.getClaudeExecutor().executeTask(
+        const result = await this.runImplementation(
           taskWithInstructions,
           executionPath,
           sessionId
@@ -977,6 +1028,7 @@ export class TaskExecutor {
   ): Promise<void> {
     try {
       this.baseBranch = config.baseBranch?.trim() || undefined;
+      this.executionMode = config.mode || 'simple';
 
       // Quiet mode: suppress all intermediate output
       const executor = this.getClaudeExecutor();

--- a/src/types/non-interactive-config.ts
+++ b/src/types/non-interactive-config.ts
@@ -1,3 +1,5 @@
+export type ExecutionMode = 'simple' | 'expert';
+
 export interface NonInteractiveConfig {
   /**
    * Task descriptions - can be a single task or multiple tasks
@@ -41,4 +43,11 @@ export interface NonInteractiveConfig {
    * and reformat the ticket as a structured Task/Acceptance Criteria prompt for Claude Code.
    */
   rewritePrompt?: boolean;
+
+  /**
+   * Execution mode.
+   * - 'simple': one-shot hand-off to Claude Code (default)
+   * - 'expert': collaborative architect↔implementer loop informed by learnings
+   */
+  mode?: ExecutionMode;
 }


### PR DESCRIPTION
This pull request introduces a mechanism to capture and persist architect critiques as institutional learnings in expert mode. After completing a task, critiques that prompted revisions will be distilled into reusable LearningRecords, enhancing the system's knowledge over time.

### Main Changes:
- Added a `captureLearnings` boolean to the collaborative config, defaulting to true.
- Implemented a new `CritiqueDistiller` class to process architect critiques and generate LearningRecords.
- Updated `CollaborativeExecutor.run` to collect critiques and invoke the distiller after task completion.
- Ensured persistence of new learnings using a merge-then-rebuild pattern, mirroring existing functionality.
- Wrapped the learning capture in a try/catch block to prevent task interruption on errors.

### Important Notes:
- The new distillation process uses OpenAI to extract generalizable lessons from critiques.
- LearningRecords are created with a new `source_type` value 'collaborative_review'.
- Type checks and linting have been performed on the modified files.

---
*Co-authored with @ivan-agent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--mode` CLI flag with "simple" and "expert" execution options
  * Expert mode enables collaborative multi-phase workflow with architect review rounds and automated learning capture from feedback
  * Added collaborative configuration settings for customizing design and review cycle limits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->