### PR TITLE
Add expert mode: collaborative architect↔implementer execution loop

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,17 @@ interface Config {
   repoAllowedTools?: { [repoPath: string]: string[] };
   repoBlockedTools?: { [repoPath: string]: string[] };
   repoInstructionsDeclined?: { [repoPath: string]: boolean };
+  collaborative?: {
+    architectModel?: string;
+    maxDesignRounds?: number;
+    maxReviewRounds?: number;
+  };
+}
+
+export interface CollaborativeConfig {
+  architectModel: string;
+  maxDesignRounds: number;
+  maxReviewRounds: number;
 }
 
 export class ConfigManager {
@@ -703,6 +714,21 @@ export class ConfigManager {
   getClaudeModel(): string {
     const config = this.getConfig();
     return config?.claudeModel || 'claude-sonnet-4-6';
+  }
+
+  /**
+   * Settings for "expert" (collaborative) execution mode, where a separate
+   * architect Claude session critiques the implementer across design and review
+   * rounds. Defaults favor a strong reasoning model for the architect role.
+   */
+  getCollaborativeConfig(): CollaborativeConfig {
+    const config = this.getConfig();
+    const c = config?.collaborative;
+    return {
+      architectModel: c?.architectModel || 'claude-opus-4-8',
+      maxDesignRounds: c?.maxDesignRounds ?? 3,
+      maxReviewRounds: c?.maxReviewRounds ?? 2
+    };
   }
 
   async promptForExecutorType(): Promise<void> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -728,10 +728,20 @@ export class ConfigManager {
   getCollaborativeConfig(): CollaborativeConfig {
     const config = this.getConfig();
     const c = config?.collaborative;
+    // config.json is untyped at runtime; sanitize so malformed values can't
+    // silently degrade expert mode (e.g. a 0/negative cap skipping the loops,
+    // or a whitespace-only model string).
+    const sanitizeRounds = (
+      value: number | undefined,
+      fallback: number
+    ): number =>
+      typeof value === 'number' && Number.isFinite(value) && value >= 1
+        ? Math.floor(value)
+        : fallback;
     return {
-      architectModel: c?.architectModel || 'claude-opus-4-8',
-      maxDesignRounds: c?.maxDesignRounds ?? 5,
-      maxReviewRounds: c?.maxReviewRounds ?? 3
+      architectModel: c?.architectModel?.trim() || 'claude-opus-4-8',
+      maxDesignRounds: sanitizeRounds(c?.maxDesignRounds, 5),
+      maxReviewRounds: sanitizeRounds(c?.maxReviewRounds, 3)
     };
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -720,14 +720,18 @@ export class ConfigManager {
    * Settings for "expert" (collaborative) execution mode, where a separate
    * architect Claude session critiques the implementer across design and review
    * rounds. Defaults favor a strong reasoning model for the architect role.
+   *
+   * maxDesignRounds / maxReviewRounds are SAFETY CEILINGS, not target counts:
+   * each loop ends as soon as the architect approves, so simple tasks finish in
+   * one round and only genuinely hard ones approach the cap.
    */
   getCollaborativeConfig(): CollaborativeConfig {
     const config = this.getConfig();
     const c = config?.collaborative;
     return {
       architectModel: c?.architectModel || 'claude-opus-4-8',
-      maxDesignRounds: c?.maxDesignRounds ?? 3,
-      maxReviewRounds: c?.maxReviewRounds ?? 2
+      maxDesignRounds: c?.maxDesignRounds ?? 5,
+      maxReviewRounds: c?.maxReviewRounds ?? 3
     };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,10 @@ import { TaskExecutor } from './services/task-executor.js';
 import { AddressExecutor } from './services/address-executor.js';
 import { DatabaseManager } from './database.js';
 import { WebServer } from './web-server.js';
-import type { NonInteractiveConfig } from './types/non-interactive-config.js';
+import type {
+  NonInteractiveConfig,
+  ExecutionMode
+} from './types/non-interactive-config.js';
 import { registerLearningsCommands } from './learnings/index.js';
 import {
   readFileSync,
@@ -36,6 +39,10 @@ program
   .option(
     '--rewrite-prompt',
     'Rewrite verbose task descriptions before execution using GPT-4o-mini'
+  )
+  .option(
+    '--mode <mode>',
+    'Execution mode: "simple" (one-shot hand-off, default) or "expert" (collaborative architect↔implementer loop informed by learnings)'
   );
 
 registerLearningsCommands(program);
@@ -655,12 +662,15 @@ async function runNonInteractive(configInput: string): Promise<void> {
     }
 
     // Apply --rewrite-prompt flag if passed on CLI
-    const { rewritePrompt, baseBranch } = program.opts<{
+    const { rewritePrompt, baseBranch, mode } = program.opts<{
       rewritePrompt: boolean;
       baseBranch?: string;
+      mode?: string;
     }>();
     if (rewritePrompt) config.rewritePrompt = true;
     if (baseBranch) config.baseBranch = baseBranch;
+    // CLI --mode overrides the config file; config value wins only if no flag.
+    if (mode !== undefined) config.mode = resolveMode(mode);
 
     // Validate config
     if (
@@ -709,16 +719,32 @@ async function runNonInteractive(configInput: string): Promise<void> {
   }
 }
 
+function resolveMode(raw: string | undefined): ExecutionMode {
+  const value = (raw || 'simple').toLowerCase();
+  if (value !== 'simple' && value !== 'expert') {
+    throw new Error(
+      `Invalid --mode "${raw}". Valid values are "simple" or "expert".`
+    );
+  }
+  return value;
+}
+
 async function main() {
   try {
     const args = process.argv.slice(2);
 
     // Parse known options early; operands are everything left after stripping flags
     const { operands } = program.parseOptions(args);
-    const { rewritePrompt: hasRewriteFlag, baseBranch } = program.opts<{
+    const {
+      rewritePrompt: hasRewriteFlag,
+      baseBranch,
+      mode: modeFlag
+    } = program.opts<{
       rewritePrompt: boolean;
       baseBranch?: string;
+      mode?: string;
     }>();
+    const mode = resolveMode(modeFlag);
 
     // Check for -c/--config flag
     const configFlagIndex = args.findIndex(
@@ -759,6 +785,7 @@ async function main() {
       const config: NonInteractiveConfig = {
         tasks: [taskDescription],
         rewritePrompt: hasRewriteFlag,
+        mode,
         ...(baseBranch && { baseBranch })
       };
 
@@ -807,7 +834,7 @@ async function main() {
       await runMigrations();
 
       const taskExecutor = new TaskExecutor();
-      await taskExecutor.executeWorkflow(hasRewriteFlag, baseBranch);
+      await taskExecutor.executeWorkflow(hasRewriteFlag, baseBranch, mode);
       return;
     }
 

--- a/src/services/claude-cli-executor.ts
+++ b/src/services/claude-cli-executor.ts
@@ -3,7 +3,11 @@ import chalk from 'chalk';
 import { ConfigManager } from '../config.js';
 import path from 'path';
 import { execSync } from 'child_process';
-import type { IClaudeExecutor } from './executor-factory.js';
+import type {
+  IClaudeExecutor,
+  TurnOptions,
+  TurnResult
+} from './executor-factory.js';
 
 export class ClaudeCliExecutor implements IClaudeExecutor {
   public quietMode: boolean = false;
@@ -26,7 +30,26 @@ export class ClaudeCliExecutor implements IClaudeExecutor {
     taskDescription: string,
     workingDir: string,
     sessionId?: string
-  ): Promise<{ log: string; lastMessage: string; sessionId: string }> {
+  ): Promise<TurnResult> {
+    return this.executeTurn(taskDescription, workingDir, {
+      sessionId,
+      permissionMode: 'bypassPermissions'
+    });
+  }
+
+  async executeTurn(
+    taskDescription: string,
+    workingDir: string,
+    options: TurnOptions = {}
+  ): Promise<TurnResult> {
+    const {
+      sessionId,
+      permissionMode = 'bypassPermissions',
+      systemPrompt,
+      model: modelOverride,
+      readOnly = false
+    } = options;
+
     console.log(
       chalk.blue(`🤖 Executing task with Claude Code CLI: ${taskDescription}`)
     );
@@ -69,8 +92,13 @@ export class ClaudeCliExecutor implements IClaudeExecutor {
       const blockedTools =
         await this.configManager.getRepoBlockedTools(originalRepoPath);
 
-      // Always block EnterPlanMode and AskUserQuestion globally
-      const globallyBlockedTools = ['EnterPlanMode', 'AskUserQuestion'];
+      // Always block EnterPlanMode and AskUserQuestion globally. In read-only
+      // (architect) turns, also block file-mutating tools.
+      const globallyBlockedTools = [
+        'EnterPlanMode',
+        'AskUserQuestion',
+        ...(readOnly ? ['Edit', 'Write', 'NotebookEdit'] : [])
+      ];
 
       // Combine globally blocked tools with repository-specific blocked tools
       const allBlockedTools = blockedTools
@@ -113,8 +141,8 @@ export class ClaudeCliExecutor implements IClaudeExecutor {
         }
       }
 
-      // Get the selected model
-      const model = this.configManager.getClaudeModel();
+      // Get the selected model (architect turns may override it)
+      const model = modelOverride || this.configManager.getClaudeModel();
 
       console.log(chalk.gray(`Working directory: ${workingDir}`));
       console.log(chalk.gray(`Model: ${model}`));
@@ -134,8 +162,13 @@ export class ClaudeCliExecutor implements IClaudeExecutor {
         '--model',
         model,
         '--permission-mode',
-        'bypassPermissions'
+        permissionMode
       ];
+
+      // Add an architect/reviewer persona or other per-turn system prompt
+      if (systemPrompt) {
+        args.push('--append-system-prompt', systemPrompt);
+      }
 
       // Add allowed tools if specified
       if (

--- a/src/services/claude-executor.ts
+++ b/src/services/claude-executor.ts
@@ -3,7 +3,11 @@ import chalk from 'chalk';
 import { ConfigManager } from '../config.js';
 import path from 'path';
 import { execSync } from 'child_process';
-import type { IClaudeExecutor } from './executor-factory.js';
+import type {
+  IClaudeExecutor,
+  TurnOptions,
+  TurnResult
+} from './executor-factory.js';
 
 export class ClaudeExecutor implements IClaudeExecutor {
   public quietMode: boolean = false;
@@ -33,7 +37,26 @@ export class ClaudeExecutor implements IClaudeExecutor {
     taskDescription: string,
     workingDir: string,
     sessionId?: string
-  ): Promise<{ log: string; lastMessage: string; sessionId: string }> {
+  ): Promise<TurnResult> {
+    return this.executeTurn(taskDescription, workingDir, {
+      sessionId,
+      permissionMode: 'bypassPermissions'
+    });
+  }
+
+  async executeTurn(
+    taskDescription: string,
+    workingDir: string,
+    options: TurnOptions = {}
+  ): Promise<TurnResult> {
+    const {
+      sessionId,
+      permissionMode = 'bypassPermissions',
+      systemPrompt,
+      model: modelOverride,
+      readOnly = false
+    } = options;
+
     if (!this.quietMode) {
       console.log(
         chalk.blue(`🤖 Executing task with Claude Code: ${taskDescription}`)
@@ -74,8 +97,14 @@ export class ClaudeExecutor implements IClaudeExecutor {
       const blockedTools =
         await this.configManager.getRepoBlockedTools(originalRepoPath);
 
-      // Always block EnterPlanMode and AskUserQuestion globally
-      const globallyBlockedTools = ['EnterPlanMode', 'AskUserQuestion'];
+      // Always block EnterPlanMode and AskUserQuestion globally. In read-only
+      // (architect) turns, also block file-mutating tools so the reviewer can
+      // inspect the worktree without changing it.
+      const globallyBlockedTools = [
+        'EnterPlanMode',
+        'AskUserQuestion',
+        ...(readOnly ? ['Edit', 'Write', 'NotebookEdit'] : [])
+      ];
 
       // Combine globally blocked tools with repository-specific blocked tools
       const allBlockedTools = blockedTools
@@ -118,8 +147,8 @@ export class ClaudeExecutor implements IClaudeExecutor {
         }
       }
 
-      // Get the selected model
-      const model = this.configManager.getClaudeModel();
+      // Get the selected model (architect turns may override it)
+      const model = modelOverride || this.configManager.getClaudeModel();
 
       if (!this.quietMode) {
         console.log(chalk.gray(`Working directory: ${workingDir}`));
@@ -160,9 +189,10 @@ export class ClaudeExecutor implements IClaudeExecutor {
             // 2) (Optional) If you sometimes hop folders, explicitly whitelist them:
             additionalDirectories: [workingDir],
 
-            // 3) Allow edit tools in headless mode:
-            //    Use 'acceptEdits' for safer default; 'bypassPermissions' is most permissive.
-            permissionMode: 'bypassPermissions',
+            // 3) Permission mode: 'plan' for design dialogue (no edits),
+            //    'bypassPermissions' for implementation turns.
+            permissionMode,
+            ...(systemPrompt !== undefined && { systemPrompt }),
             ...(allowedTools !== undefined && { allowedTools }),
             disallowedTools: allBlockedTools,
             model: model,

--- a/src/services/collaborative-executor.ts
+++ b/src/services/collaborative-executor.ts
@@ -1,8 +1,5 @@
 import chalk from 'chalk';
-import type {
-  IClaudeExecutor,
-  TurnResult
-} from './executor-factory.js';
+import type { IClaudeExecutor, TurnResult } from './executor-factory.js';
 import type { CollaborativeConfig } from '../config.js';
 import { queryLearnings } from '../learnings/index.js';
 import type { LearningsQueryResult } from '../learnings/types.js';
@@ -57,6 +54,16 @@ interface Verdict {
   notes: string;
 }
 
+export interface CollaborativeRunResult extends TurnResult {
+  /**
+   * Present when the loop proceeded despite the architect's final verdict being
+   * REVISE (round cap or stuck-detection reached). Holds the architect's
+   * unresolved concern text so the caller can surface it to the human reviewer
+   * (e.g. in the PR body) without aborting the autonomous run.
+   */
+  unresolvedConcerns?: string;
+}
+
 /**
  * Drives an "expert"-mode collaboration: a separate architect Claude session
  * critiques an implementer Claude session across a design dialogue, then the
@@ -70,7 +77,7 @@ export class CollaborativeExecutor {
     private config: CollaborativeConfig
   ) {}
 
-  async run(params: CollaborativeRunParams): Promise<TurnResult> {
+  async run(params: CollaborativeRunParams): Promise<CollaborativeRunResult> {
     const {
       taskDescription,
       executionPath,
@@ -97,6 +104,10 @@ export class CollaborativeExecutor {
 
     let implSession = incomingSessionId;
     let architectSession: string | undefined;
+    // Set when a phase proceeds despite an unresolved blocking (REVISE) verdict
+    // (round cap or stuck-detection). Surfaced to the caller so the reviewer
+    // sees what the architect rejected, without aborting the autonomous run.
+    let unresolvedConcerns: string | undefined;
 
     // ----- Phase 1: design dialogue -----
     // The number of rounds is not fixed: the loop ends as soon as the architect
@@ -150,6 +161,7 @@ export class CollaborativeExecutor {
             `⚠️  Design still has blocking concerns after ${round} round(s) (safety cap reached); proceeding with the latest plan.`
           )
         );
+        unresolvedConcerns = verdict.notes;
         break;
       }
       if (
@@ -161,6 +173,7 @@ export class CollaborativeExecutor {
             '⚠️  Architect repeated the same unresolved concern; further design rounds are unlikely to help. Proceeding.'
           )
         );
+        unresolvedConcerns = verdict.notes;
         break;
       }
       previousDesignConcern = verdict.notes;
@@ -184,6 +197,9 @@ export class CollaborativeExecutor {
       (r) => (implSession = r.sessionId)
     );
     record('Implementer — implementation', implLog);
+    // Tracks the most recent implementer output so the returned lastMessage
+    // reflects the final code after any review revisions, not the first turn.
+    let latestImplLog = implLog;
 
     // ----- Phase 3: code-review dialogue -----
     // Same dynamic termination as the design phase: ends on approval, accepts
@@ -222,9 +238,17 @@ export class CollaborativeExecutor {
       if (verdict.decision === 'nits') {
         console.log(
           chalk.green(
-            '✅ Architect approved the implementation with minor notes; not spending another round.'
+            '✅ Architect approved the implementation with minor notes; applying them without another review round.'
           )
         );
+        this.header('🔨 Implementer — applying review nits');
+        latestImplLog = await this.turn(
+          this.applyNitsPrompt(verdict.notes),
+          executionPath,
+          { sessionId: implSession, permissionMode: 'bypassPermissions' },
+          (r) => (implSession = r.sessionId)
+        );
+        record('Implementer — applied review nits', latestImplLog);
         break;
       }
       // Blocking (revise).
@@ -234,6 +258,7 @@ export class CollaborativeExecutor {
             `⚠️  Implementation still has blocking concerns after ${round} round(s) (safety cap reached); proceeding.`
           )
         );
+        unresolvedConcerns = verdict.notes;
         break;
       }
       if (
@@ -245,24 +270,26 @@ export class CollaborativeExecutor {
             '⚠️  Architect repeated the same unresolved concern; further review rounds are unlikely to help. Proceeding.'
           )
         );
+        unresolvedConcerns = verdict.notes;
         break;
       }
       previousReviewConcern = verdict.notes;
 
       this.header(`🔨 Implementer — applying review changes (round ${round})`);
-      const revisionLog = await this.turn(
+      latestImplLog = await this.turn(
         this.reviseCodePrompt(verdict.notes),
         executionPath,
         { sessionId: implSession, permissionMode: 'bypassPermissions' },
         (r) => (implSession = r.sessionId)
       );
-      record(`Implementer — revisions (round ${round})`, revisionLog);
+      record(`Implementer — revisions (round ${round})`, latestImplLog);
     }
 
     return {
       log: transcript.join('\n'),
-      lastMessage: implLog,
-      sessionId: implSession || ''
+      lastMessage: latestImplLog,
+      sessionId: implSession || '',
+      ...(unresolvedConcerns ? { unresolvedConcerns } : {})
     };
   }
 
@@ -315,9 +342,10 @@ export class CollaborativeExecutor {
     const match = message.match(
       /VERDICT:\s*(APPROVE_WITH_NITS|APPROVE|APPROVED|REVISE)/i
     );
-    // Default to approve when no explicit verdict is found, to avoid burning
-    // rounds on an ambiguous response.
-    let decision: VerdictDecision = 'approve';
+    // A missing/malformed verdict is treated as non-approval (revise): a
+    // substantive critique with a forgotten trailer must never be read as
+    // approval. The round cap bounds the downside of an over-cautious default.
+    let decision: VerdictDecision = 'revise';
     if (match) {
       const token = match[1].toUpperCase();
       if (token === 'REVISE') decision = 'revise';
@@ -440,5 +468,13 @@ Review for correctness bugs, deviations from the agreed plan, violations of the 
 ${notes}
 
 Apply these changes to the implementation now.`;
+  }
+
+  private applyNitsPrompt(notes: string): string {
+    return `Your reviewer approved the implementation with only minor, non-blocking notes:
+
+${notes}
+
+Apply these minor improvements now where reasonable. Keep the changes small and focused — do not undertake larger rework.`;
   }
 }

--- a/src/services/collaborative-executor.ts
+++ b/src/services/collaborative-executor.ts
@@ -1,0 +1,339 @@
+import chalk from 'chalk';
+import type {
+  IClaudeExecutor,
+  TurnResult
+} from './executor-factory.js';
+import type { CollaborativeConfig } from '../config.js';
+import { queryLearnings } from '../learnings/index.js';
+import type { LearningsQueryResult } from '../learnings/types.js';
+
+/**
+ * The architect persona. A separate Claude session adopts this role to critique
+ * the implementer across design and review rounds — Ivan acting as a principal
+ * engineer / critical-thinking partner rather than a one-shot dispatcher.
+ */
+const ARCHITECT_SYSTEM_PROMPT = `You are a principal engineer reviewing a teammate's work. You hold your team's hard-won institutional knowledge and you care about correctness, simplicity, and long-term maintainability.
+
+You are not the implementer — you do not write the code. Your job is to think critically: challenge questionable decisions, surface risks and edge cases, point out where the work diverges from the team's established lessons, and propose simpler or safer alternatives. Be specific and concrete; vague approval is worse than useless. You may read and inspect the codebase, but never modify it.
+
+When you finish, end your message with exactly one line, nothing after it:
+VERDICT: APPROVE
+or
+VERDICT: REVISE`;
+
+const MAX_DIFF_CHARS = 60000;
+
+export interface CollaborativeRunParams {
+  /** The task to accomplish (already including any repo-specific instructions). */
+  taskDescription: string;
+  /** The worktree path where the implementer should edit and the architect inspects. */
+  executionPath: string;
+  /**
+   * The main repository path (where `.ivan/` lives). Used to query learnings,
+   * since the worktree does not contain the learnings store.
+   */
+  learningsRepoPath: string;
+  /** Returns the current working-tree diff for the review phase. */
+  getDiff: () => string;
+  /** Optional session to resume so multi-task / single-PR runs keep context. */
+  incomingSessionId?: string;
+}
+
+interface Verdict {
+  approve: boolean;
+  /** The architect's full message, fed back to the implementer when revising. */
+  notes: string;
+}
+
+/**
+ * Drives an "expert"-mode collaboration: a separate architect Claude session
+ * critiques an implementer Claude session across a design dialogue, then the
+ * implementation, then a code-review dialogue — informed by the team's
+ * institutional learnings. The implementer's final session is returned so
+ * callers can thread context across tasks (single-PR mode).
+ */
+export class CollaborativeExecutor {
+  constructor(
+    private executor: IClaudeExecutor,
+    private config: CollaborativeConfig
+  ) {}
+
+  async run(params: CollaborativeRunParams): Promise<TurnResult> {
+    const {
+      taskDescription,
+      executionPath,
+      learningsRepoPath,
+      getDiff,
+      incomingSessionId
+    } = params;
+
+    const transcript: string[] = [];
+    const record = (heading: string, body: string) => {
+      transcript.push(`\n=== ${heading} ===\n${body}`);
+    };
+
+    this.header('🧠 Expert mode: assembling institutional knowledge');
+    const brief = await this.buildBrief(learningsRepoPath, taskDescription);
+    if (brief) {
+      console.log(chalk.gray(brief));
+      record('Institutional knowledge', brief);
+    } else {
+      console.log(
+        chalk.gray('No relevant learnings found — proceeding without a brief.')
+      );
+    }
+
+    let implSession = incomingSessionId;
+    let architectSession: string | undefined;
+
+    // ----- Phase 1: design dialogue -----
+    this.header('📐 Design dialogue');
+    let plan = await this.turn(
+      this.planPrompt(taskDescription, brief),
+      executionPath,
+      { sessionId: implSession, permissionMode: 'plan' },
+      (r) => (implSession = r.sessionId)
+    );
+    record('Implementer — proposed plan', plan);
+
+    for (let round = 1; round <= this.config.maxDesignRounds; round++) {
+      this.header(`🏛️  Architect — design review (round ${round})`);
+      const review = await this.turn(
+        this.designReviewPrompt(taskDescription, plan, brief),
+        executionPath,
+        {
+          sessionId: architectSession,
+          permissionMode: 'plan',
+          readOnly: true,
+          systemPrompt: ARCHITECT_SYSTEM_PROMPT,
+          model: this.config.architectModel
+        },
+        (r) => (architectSession = r.sessionId)
+      );
+      const verdict = this.parseVerdict(review);
+      record(`Architect — design review (round ${round})`, review);
+
+      if (verdict.approve) {
+        console.log(chalk.green('✅ Architect approved the design.'));
+        break;
+      }
+      if (round === this.config.maxDesignRounds) {
+        console.log(
+          chalk.yellow(
+            '⚠️  Design rounds exhausted; proceeding with the latest plan.'
+          )
+        );
+        break;
+      }
+
+      this.header(`🔨 Implementer — revising plan (round ${round})`);
+      plan = await this.turn(
+        this.revisePlanPrompt(verdict.notes),
+        executionPath,
+        { sessionId: implSession, permissionMode: 'plan' },
+        (r) => (implSession = r.sessionId)
+      );
+      record(`Implementer — revised plan (round ${round})`, plan);
+    }
+
+    // ----- Phase 2: implementation -----
+    this.header('🛠️  Implementation');
+    const implLog = await this.turn(
+      this.implementPrompt(),
+      executionPath,
+      { sessionId: implSession, permissionMode: 'bypassPermissions' },
+      (r) => (implSession = r.sessionId)
+    );
+    record('Implementer — implementation', implLog);
+
+    // ----- Phase 3: code-review dialogue -----
+    for (let round = 1; round <= this.config.maxReviewRounds; round++) {
+      const diff = this.truncateDiff(getDiff());
+      if (!diff.trim()) {
+        console.log(
+          chalk.yellow('⚠️  No changes to review; skipping code review.')
+        );
+        break;
+      }
+
+      this.header(`🏛️  Architect — code review (round ${round})`);
+      const review = await this.turn(
+        this.codeReviewPrompt(taskDescription, plan, diff, brief),
+        executionPath,
+        {
+          sessionId: architectSession,
+          permissionMode: 'plan',
+          readOnly: true,
+          systemPrompt: ARCHITECT_SYSTEM_PROMPT,
+          model: this.config.architectModel
+        },
+        (r) => (architectSession = r.sessionId)
+      );
+      const verdict = this.parseVerdict(review);
+      record(`Architect — code review (round ${round})`, review);
+
+      if (verdict.approve) {
+        console.log(chalk.green('✅ Architect approved the implementation.'));
+        break;
+      }
+      if (round === this.config.maxReviewRounds) {
+        console.log(
+          chalk.yellow(
+            '⚠️  Review rounds exhausted; proceeding with the current implementation.'
+          )
+        );
+        break;
+      }
+
+      this.header(`🔨 Implementer — applying review changes (round ${round})`);
+      const revisionLog = await this.turn(
+        this.reviseCodePrompt(verdict.notes),
+        executionPath,
+        { sessionId: implSession, permissionMode: 'bypassPermissions' },
+        (r) => (implSession = r.sessionId)
+      );
+      record(`Implementer — revisions (round ${round})`, revisionLog);
+    }
+
+    return {
+      log: transcript.join('\n'),
+      lastMessage: implLog,
+      sessionId: implSession || ''
+    };
+  }
+
+  /**
+   * Runs a turn, captures its session id via the callback, and returns the
+   * full output text. We use `log` (the complete transcript) rather than
+   * `lastMessage` because the CLI executor only captures the last stdout line
+   * there, which would truncate the architect's critique and verdict.
+   */
+  private async turn(
+    prompt: string,
+    executionPath: string,
+    options: Parameters<IClaudeExecutor['executeTurn']>[2],
+    onResult: (r: TurnResult) => void
+  ): Promise<string> {
+    const r = await this.executor.executeTurn(prompt, executionPath, options);
+    onResult(r);
+    return r.log?.trim() || r.lastMessage;
+  }
+
+  private async buildBrief(
+    learningsRepoPath: string,
+    taskDescription: string
+  ): Promise<string> {
+    let learnings: LearningsQueryResult[] = [];
+    try {
+      learnings = await queryLearnings(learningsRepoPath, taskDescription, {
+        limit: 8
+      });
+    } catch {
+      // No learnings store, or it failed to open — expert mode still works.
+      return '';
+    }
+    if (learnings.length === 0) return '';
+
+    return learnings
+      .map((l) => {
+        const label = l.title || l.kind;
+        const parts = [`- [${label}] ${l.statement}`];
+        if (l.rationale) parts.push(`  Why: ${l.rationale}`);
+        if (l.applicability) parts.push(`  When: ${l.applicability}`);
+        if (l.source_url) parts.push(`  Source: ${l.source_url}`);
+        return parts.join('\n');
+      })
+      .join('\n');
+  }
+
+  private parseVerdict(message: string): Verdict {
+    const match = message.match(/VERDICT:\s*(APPROVE|APPROVED|REVISE)/i);
+    // Default to approve when no explicit verdict is found, to avoid burning
+    // rounds on an ambiguous response.
+    const approve = match ? /APPROVE/i.test(match[1]) : true;
+    return { approve, notes: message };
+  }
+
+  private truncateDiff(diff: string): string {
+    if (diff.length <= MAX_DIFF_CHARS) return diff;
+    return (
+      diff.slice(0, MAX_DIFF_CHARS) +
+      `\n\n[... diff truncated at ${MAX_DIFF_CHARS} characters. Read the files directly to review the rest. ...]`
+    );
+  }
+
+  private header(text: string): void {
+    console.log('');
+    console.log(chalk.magenta.bold(text));
+  }
+
+  // ----- Prompt builders -----
+
+  private briefBlock(brief: string): string {
+    return brief
+      ? `\nRelevant institutional knowledge (lessons from this team's past PRs and coding sessions — weigh these heavily):\n${brief}\n`
+      : '';
+  }
+
+  private planPrompt(task: string, brief: string): string {
+    return `${task}
+${this.briefBlock(brief)}
+Before writing any code, think like you're pairing with a senior engineer. Produce a concise technical plan: your intended approach, the key files you'll touch, the edge cases you'll handle, and any risks or trade-offs. Do NOT implement anything yet — respond with the plan only.`;
+  }
+
+  private designReviewPrompt(
+    task: string,
+    plan: string,
+    brief: string
+  ): string {
+    return `Review a teammate's PROPOSED PLAN for the following task. No code has been written yet.
+
+TASK:
+${task}
+${this.briefBlock(brief)}
+PROPOSED PLAN:
+${plan}
+
+Scrutinize the plan. Inspect the codebase (read-only) as needed to ground your critique. Look for: a wrong or over-complicated approach, missed edge cases, anything that violates the institutional knowledge above, unaddressed risks, and simpler alternatives.`;
+  }
+
+  private revisePlanPrompt(notes: string): string {
+    return `Your reviewer (a principal engineer) raised the following on your plan:
+
+${notes}
+
+Revise your technical plan to address this feedback. Do NOT implement yet — respond with the updated plan only.`;
+  }
+
+  private implementPrompt(): string {
+    return `Your plan has been approved by the reviewer. Implement it in full now. Follow the agreed approach and honor the institutional knowledge discussed earlier.`;
+  }
+
+  private codeReviewPrompt(
+    task: string,
+    plan: string,
+    diff: string,
+    brief: string
+  ): string {
+    return `Review your teammate's IMPLEMENTATION (the diff below) for this task.
+
+TASK:
+${task}
+
+AGREED PLAN:
+${plan}
+${this.briefBlock(brief)}
+DIFF:
+${diff}
+
+Review for correctness bugs, deviations from the agreed plan, violations of the institutional knowledge, missing tests or edge cases, and simplification opportunities. You may inspect the codebase read-only.`;
+  }
+
+  private reviseCodePrompt(notes: string): string {
+    return `Your reviewer (a principal engineer) requested changes:
+
+${notes}
+
+Apply these changes to the implementation now.`;
+  }
+}

--- a/src/services/collaborative-executor.ts
+++ b/src/services/collaborative-executor.ts
@@ -16,10 +16,15 @@ const ARCHITECT_SYSTEM_PROMPT = `You are a principal engineer reviewing a teamma
 
 You are not the implementer — you do not write the code. Your job is to think critically: challenge questionable decisions, surface risks and edge cases, point out where the work diverges from the team's established lessons, and propose simpler or safer alternatives. Be specific and concrete; vague approval is worse than useless. You may read and inspect the codebase, but never modify it.
 
-When you finish, end your message with exactly one line, nothing after it:
-VERDICT: APPROVE
-or
-VERDICT: REVISE`;
+When you finish, end your message with exactly one line, nothing after it — one of:
+VERDICT: APPROVE            (the work is sound; proceed)
+VERDICT: APPROVE_WITH_NITS  (only minor, non-blocking suggestions remain — they can be folded in without another round)
+VERDICT: REVISE            (a blocking problem must be fixed before proceeding)
+
+Calibrate your verdict deliberately, because each REVISE costs a full revision round:
+- Reserve REVISE for genuinely blocking issues: incorrectness, a wrong or risky approach, violated conventions, or real unaddressed risk.
+- If the work is good enough to proceed and your remaining concerns are minor, stylistic, speculative, or better handled later, use APPROVE_WITH_NITS instead of spending another round.
+- Iterate as many rounds as the problem genuinely needs, but do not manufacture concerns to keep iterating. When a design is sound, approve it.`;
 
 const MAX_DIFF_CHARS = 60000;
 
@@ -39,8 +44,15 @@ export interface CollaborativeRunParams {
   incomingSessionId?: string;
 }
 
+/**
+ * - `approve`: sound, proceed.
+ * - `nits`: approved, but minor non-blocking notes to fold in without another round.
+ * - `revise`: a blocking concern that warrants another revision round.
+ */
+type VerdictDecision = 'approve' | 'nits' | 'revise';
+
 interface Verdict {
-  approve: boolean;
+  decision: VerdictDecision;
   /** The architect's full message, fed back to the implementer when revising. */
   notes: string;
 }
@@ -87,6 +99,9 @@ export class CollaborativeExecutor {
     let architectSession: string | undefined;
 
     // ----- Phase 1: design dialogue -----
+    // The number of rounds is not fixed: the loop ends as soon as the architect
+    // approves (or approves with nits), stops early if a concern is repeated
+    // unresolved, and only otherwise runs up to maxDesignRounds as a safety cap.
     this.header('📐 Design dialogue');
     let plan = await this.turn(
       this.planPrompt(taskDescription, brief),
@@ -96,6 +111,8 @@ export class CollaborativeExecutor {
     );
     record('Implementer — proposed plan', plan);
 
+    let designNits: string | undefined;
+    let previousDesignConcern: string | undefined;
     for (let round = 1; round <= this.config.maxDesignRounds; round++) {
       this.header(`🏛️  Architect — design review (round ${round})`);
       const review = await this.turn(
@@ -113,18 +130,40 @@ export class CollaborativeExecutor {
       const verdict = this.parseVerdict(review);
       record(`Architect — design review (round ${round})`, review);
 
-      if (verdict.approve) {
+      if (verdict.decision === 'approve') {
         console.log(chalk.green('✅ Architect approved the design.'));
         break;
       }
+      if (verdict.decision === 'nits') {
+        console.log(
+          chalk.green(
+            '✅ Architect approved the design with minor notes (folded into implementation).'
+          )
+        );
+        designNits = verdict.notes;
+        break;
+      }
+      // Blocking (revise).
       if (round === this.config.maxDesignRounds) {
         console.log(
           chalk.yellow(
-            '⚠️  Design rounds exhausted; proceeding with the latest plan.'
+            `⚠️  Design still has blocking concerns after ${round} round(s) (safety cap reached); proceeding with the latest plan.`
           )
         );
         break;
       }
+      if (
+        previousDesignConcern &&
+        this.isRepeatConcern(previousDesignConcern, verdict.notes)
+      ) {
+        console.log(
+          chalk.yellow(
+            '⚠️  Architect repeated the same unresolved concern; further design rounds are unlikely to help. Proceeding.'
+          )
+        );
+        break;
+      }
+      previousDesignConcern = verdict.notes;
 
       this.header(`🔨 Implementer — revising plan (round ${round})`);
       plan = await this.turn(
@@ -139,7 +178,7 @@ export class CollaborativeExecutor {
     // ----- Phase 2: implementation -----
     this.header('🛠️  Implementation');
     const implLog = await this.turn(
-      this.implementPrompt(),
+      this.implementPrompt(designNits),
       executionPath,
       { sessionId: implSession, permissionMode: 'bypassPermissions' },
       (r) => (implSession = r.sessionId)
@@ -147,6 +186,10 @@ export class CollaborativeExecutor {
     record('Implementer — implementation', implLog);
 
     // ----- Phase 3: code-review dialogue -----
+    // Same dynamic termination as the design phase: ends on approval, accepts
+    // minor nits without another round, stops on a repeated unresolved concern,
+    // and uses maxReviewRounds only as a safety cap.
+    let previousReviewConcern: string | undefined;
     for (let round = 1; round <= this.config.maxReviewRounds; round++) {
       const diff = this.truncateDiff(getDiff());
       if (!diff.trim()) {
@@ -172,18 +215,39 @@ export class CollaborativeExecutor {
       const verdict = this.parseVerdict(review);
       record(`Architect — code review (round ${round})`, review);
 
-      if (verdict.approve) {
+      if (verdict.decision === 'approve') {
         console.log(chalk.green('✅ Architect approved the implementation.'));
         break;
       }
-      if (round === this.config.maxReviewRounds) {
+      if (verdict.decision === 'nits') {
         console.log(
-          chalk.yellow(
-            '⚠️  Review rounds exhausted; proceeding with the current implementation.'
+          chalk.green(
+            '✅ Architect approved the implementation with minor notes; not spending another round.'
           )
         );
         break;
       }
+      // Blocking (revise).
+      if (round === this.config.maxReviewRounds) {
+        console.log(
+          chalk.yellow(
+            `⚠️  Implementation still has blocking concerns after ${round} round(s) (safety cap reached); proceeding.`
+          )
+        );
+        break;
+      }
+      if (
+        previousReviewConcern &&
+        this.isRepeatConcern(previousReviewConcern, verdict.notes)
+      ) {
+        console.log(
+          chalk.yellow(
+            '⚠️  Architect repeated the same unresolved concern; further review rounds are unlikely to help. Proceeding.'
+          )
+        );
+        break;
+      }
+      previousReviewConcern = verdict.notes;
 
       this.header(`🔨 Implementer — applying review changes (round ${round})`);
       const revisionLog = await this.turn(
@@ -247,11 +311,46 @@ export class CollaborativeExecutor {
   }
 
   private parseVerdict(message: string): Verdict {
-    const match = message.match(/VERDICT:\s*(APPROVE|APPROVED|REVISE)/i);
+    // Order matters: APPROVE_WITH_NITS must be tested before APPROVE.
+    const match = message.match(
+      /VERDICT:\s*(APPROVE_WITH_NITS|APPROVE|APPROVED|REVISE)/i
+    );
     // Default to approve when no explicit verdict is found, to avoid burning
     // rounds on an ambiguous response.
-    const approve = match ? /APPROVE/i.test(match[1]) : true;
-    return { approve, notes: message };
+    let decision: VerdictDecision = 'approve';
+    if (match) {
+      const token = match[1].toUpperCase();
+      if (token === 'REVISE') decision = 'revise';
+      else if (token === 'APPROVE_WITH_NITS') decision = 'nits';
+      else decision = 'approve';
+    }
+    return { decision, notes: message };
+  }
+
+  /**
+   * Best-effort detection of a repeated, unresolved concern. If the architect's
+   * new critique is lexically near-identical to the previous round's, the
+   * implementer likely could not resolve it and further rounds won't help, so we
+   * stop and proceed. The threshold is high to avoid halting on genuinely new
+   * feedback; the round cap remains the ultimate backstop.
+   */
+  private isRepeatConcern(previous: string, current: string): boolean {
+    const tokenize = (s: string): Set<string> =>
+      new Set(
+        s
+          .toLowerCase()
+          .replace(/verdict:\s*\w+/gi, '')
+          .replace(/[^a-z0-9\s]/g, ' ')
+          .split(/\s+/)
+          .filter((w) => w.length > 3)
+      );
+    const a = tokenize(previous);
+    const b = tokenize(current);
+    if (a.size === 0 || b.size === 0) return false;
+    let intersection = 0;
+    for (const word of a) if (b.has(word)) intersection++;
+    const union = a.size + b.size - intersection;
+    return union > 0 && intersection / union >= 0.85;
   }
 
   private truncateDiff(diff: string): string {
@@ -305,8 +404,14 @@ ${notes}
 Revise your technical plan to address this feedback. Do NOT implement yet — respond with the updated plan only.`;
   }
 
-  private implementPrompt(): string {
-    return `Your plan has been approved by the reviewer. Implement it in full now. Follow the agreed approach and honor the institutional knowledge discussed earlier.`;
+  private implementPrompt(nits?: string): string {
+    const base = `Your plan has been approved by the reviewer. Implement it in full now. Follow the agreed approach and honor the institutional knowledge discussed earlier.`;
+    if (!nits) return base;
+    return `${base}
+
+The reviewer approved the design but left minor, non-blocking notes. Address them where reasonable as you implement:
+
+${nits}`;
   }
 
   private codeReviewPrompt(

--- a/src/services/executor-factory.ts
+++ b/src/services/executor-factory.ts
@@ -2,13 +2,46 @@ import { ClaudeExecutor } from './claude-executor.js';
 import { ClaudeCliExecutor } from './claude-cli-executor.js';
 import { ConfigManager } from '../config.js';
 
+export interface TurnResult {
+  log: string;
+  lastMessage: string;
+  sessionId: string;
+}
+
+export interface TurnOptions {
+  /** Resume an existing Claude session to preserve conversational context. */
+  sessionId?: string;
+  /** Permission mode for this turn. 'plan' prevents edits (design dialogue). */
+  permissionMode?: 'plan' | 'acceptEdits' | 'bypassPermissions';
+  /** Optional system prompt to shape the turn (e.g. the architect persona). */
+  systemPrompt?: string;
+  /** Override the configured model for this turn (e.g. the architect model). */
+  model?: string;
+  /**
+   * When true, disallow file-mutating tools (Edit/Write/NotebookEdit) so the
+   * session can read, grep, and inspect but not modify the worktree. Used for
+   * the architect/reviewer role.
+   */
+  readOnly?: boolean;
+}
+
 export interface IClaudeExecutor {
   quietMode: boolean;
   executeTask(
     taskDescription: string,
     workingDir: string,
     sessionId?: string
-  ): Promise<{ log: string; lastMessage: string; sessionId: string }>;
+  ): Promise<TurnResult>;
+  /**
+   * Execute a single conversational turn with fine-grained control over
+   * session continuity, permission mode, system prompt, model, and tool access.
+   * `executeTask` is a thin wrapper over this with implementer defaults.
+   */
+  executeTurn(
+    prompt: string,
+    workingDir: string,
+    options?: TurnOptions
+  ): Promise<TurnResult>;
   generateTaskBreakdown(
     jobDescription: string,
     workingDir: string

--- a/src/services/task-executor.ts
+++ b/src/services/task-executor.ts
@@ -19,6 +19,9 @@ import {
   createRepositoryManager
 } from './service-factory.js';
 import { PromptRewriter } from './prompt-rewriter.js';
+import { CollaborativeExecutor } from './collaborative-executor.js';
+import type { ExecutionMode } from '../types/non-interactive-config.js';
+import type { TurnResult } from './executor-factory.js';
 
 export class TaskExecutor {
   private jobManager: JobManager;
@@ -30,6 +33,7 @@ export class TaskExecutor {
   private workingDir: string;
   private repoInstructions: string | undefined;
   private baseBranch: string | undefined;
+  private executionMode: ExecutionMode;
 
   constructor() {
     this.jobManager = new JobManager();
@@ -38,6 +42,42 @@ export class TaskExecutor {
     this.workingDir = '';
     this.repoInstructions = undefined;
     this.baseBranch = undefined;
+    this.executionMode = 'simple';
+  }
+
+  /**
+   * Runs the implementation for a task, branching on execution mode:
+   * - 'simple': a single one-shot hand-off to Claude Code (default)
+   * - 'expert': a collaborative architect↔implementer loop informed by learnings
+   */
+  private async runImplementation(
+    taskWithInstructions: string,
+    executionPath: string,
+    sessionId?: string
+  ): Promise<TurnResult> {
+    if (this.executionMode === 'expert') {
+      const collaborative = new CollaborativeExecutor(
+        this.getClaudeExecutor(),
+        this.configManager.getCollaborativeConfig()
+      );
+      return collaborative.run({
+        taskDescription: taskWithInstructions,
+        executionPath,
+        learningsRepoPath: this.workingDir,
+        getDiff: () => {
+          if (!this.gitManager) {
+            throw new Error('GitManager not initialized');
+          }
+          return this.gitManager.getDiff();
+        },
+        incomingSessionId: sessionId
+      });
+    }
+    return this.getClaudeExecutor().executeTask(
+      taskWithInstructions,
+      executionPath,
+      sessionId
+    );
   }
 
   private getClaudeExecutor(): IClaudeExecutor {
@@ -56,10 +96,21 @@ export class TaskExecutor {
 
   async executeWorkflow(
     rewritePrompt: boolean = false,
-    baseBranch?: string
+    baseBranch?: string,
+    mode: ExecutionMode = 'simple'
   ): Promise<void> {
     try {
       this.baseBranch = baseBranch?.trim() || undefined;
+      this.executionMode = mode;
+
+      if (mode === 'expert') {
+        console.log(
+          chalk.magenta.bold(
+            '🧠 Expert mode: Ivan will act as a principal engineer, ' +
+              'critiquing the design and implementation across rounds.'
+          )
+        );
+      }
 
       console.log(chalk.blue.bold('🚀 Starting Ivan workflow'));
       console.log('');
@@ -428,7 +479,7 @@ export class TaskExecutor {
 
       // Use worktree path for Claude execution, falling back to workingDir if needed
       const executionPath = worktreePath || this.workingDir;
-      const result = await this.getClaudeExecutor().executeTask(
+      const result = await this.runImplementation(
         taskWithInstructions,
         executionPath
       );
@@ -731,7 +782,7 @@ export class TaskExecutor {
         // Use worktree path for Claude execution
         const executionPath = worktreePath || this.workingDir;
         // Pass session ID to maintain context between tasks
-        const result = await this.getClaudeExecutor().executeTask(
+        const result = await this.runImplementation(
           taskWithInstructions,
           executionPath,
           sessionId
@@ -977,6 +1028,7 @@ export class TaskExecutor {
   ): Promise<void> {
     try {
       this.baseBranch = config.baseBranch?.trim() || undefined;
+      this.executionMode = config.mode || 'simple';
 
       // Quiet mode: suppress all intermediate output
       const executor = this.getClaudeExecutor();

--- a/src/services/task-executor.ts
+++ b/src/services/task-executor.ts
@@ -22,6 +22,7 @@ import { PromptRewriter } from './prompt-rewriter.js';
 import { CollaborativeExecutor } from './collaborative-executor.js';
 import type { ExecutionMode } from '../types/non-interactive-config.js';
 import type { TurnResult } from './executor-factory.js';
+import type { CollaborativeRunResult } from './collaborative-executor.js';
 
 export class TaskExecutor {
   private jobManager: JobManager;
@@ -46,6 +47,30 @@ export class TaskExecutor {
   }
 
   /**
+   * Prepends an architect's unresolved-concern warning to a PR body when expert
+   * mode proceeded past its review limit with blocking concerns still open. Keeps
+   * the run autonomous while making sure the human reviewer sees what was rejected.
+   */
+  private prependConcerns(body: string, concerns: string[]): string {
+    const valid = concerns.filter((c) => c && c.trim());
+    if (valid.length === 0) return body;
+
+    const MAX_CONCERN_LENGTH = 4000;
+    const sections = valid.map((concern) => {
+      const cleaned = concern.replace(/VERDICT:\s*\w+\s*$/gim, '').trim();
+      return cleaned.length > MAX_CONCERN_LENGTH
+        ? `${cleaned.slice(0, MAX_CONCERN_LENGTH)}\n\n…(truncated)`
+        : cleaned;
+    });
+
+    const warning =
+      '> [!WARNING]\n' +
+      '> **The architect had unresolved concerns when expert mode reached its review limit and proceeded autonomously.** Please review these before merging.';
+
+    return `${warning}\n\n${sections.join('\n\n---\n\n')}\n\n---\n\n${body}`;
+  }
+
+  /**
    * Runs the implementation for a task, branching on execution mode:
    * - 'simple': a single one-shot hand-off to Claude Code (default)
    * - 'expert': a collaborative architect↔implementer loop informed by learnings
@@ -54,7 +79,7 @@ export class TaskExecutor {
     taskWithInstructions: string,
     executionPath: string,
     sessionId?: string
-  ): Promise<TurnResult> {
+  ): Promise<TurnResult & Pick<CollaborativeRunResult, 'unresolvedConcerns'>> {
     if (this.executionMode === 'expert') {
       const collaborative = new CollaborativeExecutor(
         this.getClaudeExecutor(),
@@ -663,7 +688,11 @@ export class TaskExecutor {
       if (!this.gitManager) {
         throw new Error('GitManager not initialized');
       }
-      const prUrl = await this.gitManager.createPullRequest(title, body);
+      const prBody = this.prependConcerns(
+        body,
+        result.unresolvedConcerns ? [result.unresolvedConcerns] : []
+      );
+      const prUrl = await this.gitManager.createPullRequest(title, prBody);
       if (spinner) spinner.succeed(`Pull request created: ${prUrl}`);
 
       await this.jobManager.updateTaskPrLink(task.uuid, prUrl);
@@ -722,6 +751,7 @@ export class TaskExecutor {
     let worktreePath: string | null = null;
     let branchName: string | null = null;
     let sessionId: string | undefined;
+    const unresolvedConcerns: string[] = [];
 
     try {
       if (!this.gitManager) {
@@ -789,6 +819,11 @@ export class TaskExecutor {
         );
         // Store the session ID for the next task
         sessionId = result.sessionId;
+        if (result.unresolvedConcerns) {
+          unresolvedConcerns.push(
+            `**${task.description}**\n\n${result.unresolvedConcerns}`
+          );
+        }
         if (spinner) {
           spinner.succeed('Claude Code execution completed');
         }
@@ -986,7 +1021,8 @@ export class TaskExecutor {
       if (spinner) spinner.succeed('PR description generated');
 
       if (!quiet) spinner = ora('Creating pull request...').start();
-      const prUrl = await this.gitManager.createPullRequest(title, body);
+      const prBody = this.prependConcerns(body, unresolvedConcerns);
+      const prUrl = await this.gitManager.createPullRequest(title, prBody);
       if (spinner) spinner.succeed(`Pull request created: ${prUrl}`);
 
       // Update all tasks with the same PR link

--- a/src/types/non-interactive-config.ts
+++ b/src/types/non-interactive-config.ts
@@ -1,3 +1,5 @@
+export type ExecutionMode = 'simple' | 'expert';
+
 export interface NonInteractiveConfig {
   /**
    * Task descriptions - can be a single task or multiple tasks
@@ -41,4 +43,11 @@ export interface NonInteractiveConfig {
    * and reformat the ticket as a structured Task/Acceptance Criteria prompt for Claude Code.
    */
   rewritePrompt?: boolean;
+
+  /**
+   * Execution mode.
+   * - 'simple': one-shot hand-off to Claude Code (default)
+   * - 'expert': collaborative architect↔implementer loop informed by learnings
+   */
+  mode?: ExecutionMode;
 }


### PR DESCRIPTION
## Expert mode: Ivan as a principal engineer

Adds a second execution mode (`--mode expert`) that turns Ivan from a one-shot dispatcher into a critical-thinking partner. Defaults to `simple` (today's one-shot hand-off) — **zero behavior change unless you opt in.**

### What it does
Instead of a single `query()` hand-off to Claude Code, expert mode splits the two roles that were collapsed into one call and runs a multi-turn dialogue between them:

- **Architect** — a separate Opus session, read-only, carrying the team's institutional knowledge. Critiques, challenges decisions, surfaces risks.
- **Implementer** — the existing executor session with edit tools, does the work.

The loop:
1. **Context assembly** — retrieves relevant lessons from the `.ivan` learnings store (`queryLearnings`) into a brief. *This wires up the previously-built-but-disconnected learnings system into execution for the first time.*
2. **Design dialogue** — implementer proposes a plan (plan mode, no edits); architect critiques until `VERDICT: APPROVE` or `maxDesignRounds` (default 3).
3. **Implementation** — implementer builds the agreed plan.
4. **Code-review dialogue** — architect reviews the diff against plan + learnings until approve or `maxReviewRounds` (default 2). Then the usual commit/push/PR.

### Changes
- `--mode <simple|expert>` flag, validated and threaded through interactive, bare-task, and non-interactive paths.
- `IClaudeExecutor.executeTurn()` — fine-grained turn control (session, permission mode, system prompt, model, read-only); `executeTask` becomes a thin wrapper. Implemented in both SDK and CLI executors.
- `CollaborativeExecutor` — the loop.
- `collaborative` config block (architect model defaults to `claude-opus-4-8`, round caps).

### Cost
Expert mode is ~4–8× the tokens of a simple run (two sessions × several rounds, Opus critic). Opt-in by design; round caps bound it.

Co-authored with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --mode CLI flag to choose execution mode ("simple" or "expert"); non-interactive runs respect this mode.
  * Expert mode: collaborative architect↔implementer workflow with iterative design, verdicts, implementation, and code-review rounds.
  * Collaborative settings added with sensible defaults and iteration limits for expert runs.
  * Task execution now routes by mode and will surface unresolved concerns at PR creation.

* **Behavior**
  * Read-only runs enforce stricter tool blocking; executors support per-turn system prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->