### PR TITLE
Add loop mode: product-review improvement loop with optional Playwright UX probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Give Ivan a sentence. Ivan breaks it into PR-sized tasks, **debates its own desi
 npm i -g @ariso-ai/ivan && ivan "Add rate limiting to the public API"
 ```
 
-[Quick Start](#-quick-start) · [Expert Mode](#-expert-mode-an-ai-that-argues-with-itself-so-you-dont-have-to) · [Institutional Memory](#-institutional-memory-ivan-learns-your-team) · [Commands](#-cli-reference) · [Contributing](#-contributing)
+[Quick Start](#-quick-start) · [Expert Mode](#-expert-mode-an-ai-that-argues-with-itself-so-you-dont-have-to) · [Loop Mode](#-loop-mode-keep-going-until-its-actually-good) · [Institutional Memory](#-institutional-memory-ivan-learns-your-team) · [Commands](#-cli-reference) · [Contributing](#-contributing)
 
 </div>
 
@@ -63,12 +63,13 @@ ivan --mode expert "Refactor the billing module to support proration"
 
 ## 🏛️ Expert Mode: an AI that argues with itself so you don't have to
 
-Ivan ships two execution modes. Pick per-run with `--mode`:
+Ivan ships three execution modes. Pick per-run with `--mode`:
 
 | Mode | What it does | Best for |
 | --- | --- | --- |
 | **`simple`** *(default)* | A fast, one-shot hand-off to Claude Code. | Quick changes, well-scoped tasks. |
 | **`expert`** | A collaborative **architect ↔ implementer** loop, grounded in your team's learnings. | High-stakes changes where design quality matters. |
+| **`loop`** | Everything `expert` does, then a **product-review loop** that pushes for feature & UX improvements. | When "correct" isn't enough and you want the result to be *good*. |
 
 In **Expert mode**, Ivan splits into two minds. The **Implementer** writes the code. A separate **Architect** session — adopting a principal-engineer persona that *holds your team's institutional knowledge* — challenges it. They go back and forth on the **design**, then on the **diff**, and the Architect decides when the work is good enough to ship.
 
@@ -97,10 +98,50 @@ In **Expert mode**, Ivan splits into two minds. The **Implementer** writes the c
   "collaborative": {
     "architectModel": "claude-opus-4-8", // the reviewer's brain
     "maxDesignRounds": 5,                 // max design back-and-forths before building
-    "maxReviewRounds": 3                  // max code-review back-and-forths before shipping
+    "maxReviewRounds": 3,                 // max code-review back-and-forths before shipping
+    "productModel": "claude-opus-4-8",   // loop mode's product reviewer (defaults to architectModel)
+    "maxImprovementRounds": 3,           // loop mode: max feature/UX improvement rounds
+    "uxProbe": {                          // loop mode: judge UX from the *rendered* UI (see below)
+      "enabled": false,                   //   off by default — launching a dev server is a real side effect
+      "startCommand": "npm run dev",      //   how to start the app (inferred from package.json if omitted)
+      "url": "http://localhost:3000"      //   where it serves
+    }
   }
 }
 ```
+
+---
+
+## 🔁 Loop Mode: keep going until it's actually *good*
+
+Expert mode answers *"is this correct?"* Loop mode asks the next question — *"is this good?"* — and keeps iterating until the answer is yes.
+
+`--mode loop` runs the **full expert collaboration first** (so improvements are built on a correct baseline), then adds a fourth phase: a **product-minded reviewer** looks at your original request and the implemented diff and hunts for what would make it genuinely better — in **features** and in **UX**. In-scope improvements get built; larger ideas get surfaced to the PR instead of quietly ballooning it.
+
+```bash
+ivan --mode loop "Add a CLI command to export analytics as CSV"
+```
+
+```
+   ✅ expert baseline (design → implement → review)
+                          │
+                          ▼
+   ┌──────────────────┐   what could be better?   ┌──────────────────────────┐
+   │  🔨 Implementer  │ ◀════════════════════════ │  🔭 Product reviewer      │
+   │  applies in-scope │  IMPROVE ⟳  /  SHIP ✅    │  staff eng + designer     │
+   └──────────────────┘   improvements each round │  read-only, never edits  │
+                          │
+                          ▼
+     features + UX polished in-scope   ──▶   🔭 larger ideas surfaced on the PR
+```
+
+- **Feature + UX lens.** The reviewer looks for capability gaps the request implies, plus UX quality — error / empty / loading states, sensible defaults, feedback, discoverability, accessibility, and consistency with the rest of the product. Concrete suggestions only, never vague "polish it."
+- **Scope-disciplined.** Each improvement is tagged `now` (small, safe, in-scope → built this PR) or `future` (larger or scope-broadening → **surfaced, not built**). When in doubt it defers, so your PR stays reviewable.
+- **"Future improvements" on the PR.** Deferred ideas land in a dedicated section of the PR body — proposed for you to consider, never auto-applied.
+- **Grounded in loop engineering.** A *separate, skeptical evaluator* (an independent reviewer critiques far better than a generator grading its own work), fed real ground truth (the actual diff + codebase), converging fast: it ships the moment nothing in-scope is worth adding, and `maxImprovementRounds` is only a safety cap.
+- **Visual UX probe (opt-in).** By default the reviewer judges UX from the *code*. Set `collaborative.uxProbe.enabled` and — when the repo has **Playwright** and the change touches UI — the reviewer instead **runs the app, drives Playwright to the affected screens, and reads back screenshots** to critique the *rendered* result (real error/empty/loading states, layout, spacing). That review turn is granted command execution but stays **read-only for source** (it can run the app, never edit it), and falls back to a static review if it can't launch. Off by default because starting a dev server is a real side effect.
+
+> **Why not just always loop?** Because the improvement loop costs extra tokens and time, and correctness — not extra features — is the point for most changes. Reach for `loop` when the *quality* of the result matters more than raw speed; stick with `expert` (or `simple`) otherwise.
 
 ---
 
@@ -225,6 +266,7 @@ ivan config-blocked-tools     # block specific tools (least-privilege by repo)
 ivan                          # interactive: Ivan asks what to build
 ivan "task description"       # headless: run a task directly
 ivan --mode expert "task"     # collaborative architect ↔ implementer loop
+ivan --mode loop "task"       # expert + a product-review loop for feature/UX gains
 ivan --base-branch dev "task" # branch work off a specific local base branch
 ivan -c config.json           # run from a JSON config (CI-friendly)
 ivan -c '{"tasks":["A","B"],"mode":"expert"}'   # inline JSON config
@@ -286,7 +328,7 @@ Open http://localhost:3000 to watch jobs, task progress, execution logs, and PR 
 ```
 request ─▶ task breakdown ─▶ branch ─▶ implement ─▶ smart commit ─▶ PR
                                   │                                    │
-                          (expert mode: design + review rounds)  (optional: wait & auto-address)
+              (expert: design + review rounds; loop: + improvement rounds)  (optional: wait & auto-address)
 ```
 
 **Address workflow** — finds unresolved inline comments via the GitHub GraphQL API, implements each fix, replies with the fixing commit, and adds context-specific review instructions.
@@ -301,8 +343,8 @@ request ─▶ task breakdown ─▶ branch ─▶ implement ─▶ smart commit
 ivan/
 ├── src/
 │   ├── services/
-│   │   ├── task-executor.ts          # orchestrates the build workflow (simple | expert)
-│   │   ├── collaborative-executor.ts # the architect ↔ implementer loop (expert mode)
+│   │   ├── task-executor.ts          # orchestrates the build workflow (simple | expert | loop)
+│   │   ├── collaborative-executor.ts # the architect ↔ implementer loop + improvement loop (expert/loop)
 │   │   ├── claude-executor.ts        # Claude Code SDK driver
 │   │   ├── claude-cli-executor.ts    # Claude Code CLI driver (Claude Max)
 │   │   ├── address-executor.ts       # PR comment addressing workflow

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "typecheck": "tsc --noEmit",
+    "test:unit": "tsx --test src/services/*.test.ts",
     "test": "npm run build && node --experimental-vm-modules ./node_modules/jest/bin/jest.js --runInBand --config jest.config.cjs",
     "test:e2e:learnings": "node scripts/test-learnings-e2e.mjs",
     "prepare": "npm run build && git config core.hooksPath .githooks"

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,13 @@ interface Config {
     architectModel?: string;
     maxDesignRounds?: number;
     maxReviewRounds?: number;
+    productModel?: string;
+    maxImprovementRounds?: number;
+    uxProbe?: {
+      enabled?: boolean;
+      startCommand?: string;
+      url?: string;
+    };
   };
 }
 
@@ -30,6 +37,30 @@ export interface CollaborativeConfig {
   architectModel: string;
   maxDesignRounds: number;
   maxReviewRounds: number;
+  /**
+   * Model for the "loop"-mode product reviewer (Phase 4). An independent,
+   * skeptical evaluator works best on a strong reasoning model, so this
+   * defaults to the architect's model.
+   */
+  productModel: string;
+  /**
+   * Safety ceiling on "loop"-mode improvement rounds. Like the design/review
+   * caps this is a bound, not a target: the loop stops as soon as the reviewer
+   * ships or stops finding in-scope improvements.
+   */
+  maxImprovementRounds: number;
+  /**
+   * "loop"-mode visual UX probe. When enabled and the worktree supports
+   * Playwright, the product reviewer is told to run the app and drive Playwright
+   * to observe the *rendered* UI (screenshots it Reads back) before judging UX,
+   * and its review turn is granted command execution while staying read-only for
+   * source files. Off by default — launching a dev server is a real side effect.
+   */
+  uxProbe: {
+    enabled: boolean;
+    startCommand?: string;
+    url?: string;
+  };
 }
 
 export class ConfigManager {
@@ -738,10 +769,19 @@ export class ConfigManager {
       typeof value === 'number' && Number.isFinite(value) && value >= 1
         ? Math.floor(value)
         : fallback;
+    const architectModel = c?.architectModel?.trim() || 'claude-opus-4-8';
+    const uxProbe = c?.uxProbe;
     return {
-      architectModel: c?.architectModel?.trim() || 'claude-opus-4-8',
+      architectModel,
       maxDesignRounds: sanitizeRounds(c?.maxDesignRounds, 5),
-      maxReviewRounds: sanitizeRounds(c?.maxReviewRounds, 3)
+      maxReviewRounds: sanitizeRounds(c?.maxReviewRounds, 3),
+      productModel: c?.productModel?.trim() || architectModel,
+      maxImprovementRounds: sanitizeRounds(c?.maxImprovementRounds, 3),
+      uxProbe: {
+        enabled: uxProbe?.enabled === true,
+        startCommand: uxProbe?.startCommand?.trim() || undefined,
+        url: uxProbe?.url?.trim() || undefined
+      }
     };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ program
   )
   .option(
     '--mode <mode>',
-    'Execution mode: "simple" (one-shot hand-off, default) or "expert" (collaborative architect↔implementer loop informed by learnings)'
+    'Execution mode: "simple" (one-shot hand-off, default), "expert" (collaborative architect↔implementer loop informed by learnings), or "loop" (expert, then a product-review loop pushing for feature/UX improvements)'
   );
 
 registerLearningsCommands(program);
@@ -770,9 +770,9 @@ async function runNonInteractive(configInput: string): Promise<void> {
 
 function resolveMode(raw: string | undefined): ExecutionMode {
   const value = (raw || 'simple').toLowerCase();
-  if (value !== 'simple' && value !== 'expert') {
+  if (value !== 'simple' && value !== 'expert' && value !== 'loop') {
     throw new Error(
-      `Invalid --mode "${raw}". Valid values are "simple" or "expert".`
+      `Invalid --mode "${raw}". Valid values are "simple", "expert", or "loop".`
     );
   }
   return value;

--- a/src/services/collaborative-executor.test.ts
+++ b/src/services/collaborative-executor.test.ts
@@ -1,0 +1,386 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
+import { CollaborativeExecutor } from './collaborative-executor.js';
+import type {
+  IClaudeExecutor,
+  TurnResult,
+  TurnOptions
+} from './executor-factory.js';
+import type { CollaborativeConfig } from '../config.js';
+import type { CollaborativeRunResult } from './collaborative-executor.js';
+
+/**
+ * These tests drive the whole expert/loop collaboration offline via the
+ * constructor's IClaudeExecutor seam — no Claude, git, or network. The fake
+ * decides which persona is "speaking" from options.systemPrompt (architect vs
+ * product reviewer) and reads scripted product-review responses from a queue,
+ * so we can assert Phase 4's termination behavior deterministically.
+ *
+ * buildBrief is exercised too: learningsRepoPath points at an empty temp dir, so
+ * openLearningsDatabase throws (missing store), buildBrief swallows it, and no
+ * embedding/network call is ever reached.
+ */
+
+const CFG: CollaborativeConfig = {
+  architectModel: 'test-model',
+  maxDesignRounds: 3,
+  maxReviewRounds: 3,
+  productModel: 'test-model',
+  maxImprovementRounds: 3,
+  uxProbe: { enabled: false }
+};
+
+const DIFF = 'diff --git a/f b/f\n@@\n+const x = 1;';
+
+interface FakeCounts {
+  architectReviews: number;
+  productReviews: number;
+  applyImprovements: number;
+  applyPrompts: string[];
+  lastProductPrompt: string;
+  lastProductPermission?: string;
+}
+
+function makeFake(reviews: string[]): {
+  fake: IClaudeExecutor;
+  counts: FakeCounts;
+} {
+  const counts: FakeCounts = {
+    architectReviews: 0,
+    productReviews: 0,
+    applyImprovements: 0,
+    applyPrompts: [],
+    lastProductPrompt: ''
+  };
+  let reviewIdx = 0;
+  const turn = (text: string): TurnResult => ({
+    log: text,
+    lastMessage: text,
+    sessionId: 'sess'
+  });
+
+  const fake: IClaudeExecutor = {
+    quietMode: true,
+    async executeTurn(
+      prompt: string,
+      _dir: string,
+      options: TurnOptions = {}
+    ): Promise<TurnResult> {
+      const systemPrompt = options.systemPrompt ?? '';
+      // Architect persona (design + code review) — always approve so Phases
+      // 1-3 finish in one round each and Phase 4 gets to run.
+      if (systemPrompt.includes('principal engineer')) {
+        counts.architectReviews++;
+        return turn('Looks sound.\nVERDICT: APPROVE');
+      }
+      // Product reviewer persona (Phase 4) — scripted responses.
+      if (systemPrompt.includes('product-minded')) {
+        counts.productReviews++;
+        counts.lastProductPrompt = prompt;
+        counts.lastProductPermission = options.permissionMode;
+        const text = reviews[reviewIdx] ?? 'VERDICT: SHIP';
+        reviewIdx++;
+        return turn(text);
+      }
+      // Implementer — distinguish the "apply improvements" turn by its prompt.
+      if (prompt.includes('in-scope improvements to apply')) {
+        counts.applyImprovements++;
+        counts.applyPrompts.push(prompt);
+      }
+      return turn('done');
+    },
+    async executeTask(): Promise<TurnResult> {
+      return turn('done');
+    },
+    async generateTaskBreakdown(): Promise<string[]> {
+      return [];
+    },
+    async validateClaudeCodeInstallation(): Promise<void> {}
+  };
+
+  return { fake, counts };
+}
+
+function runLoop(
+  fake: IClaudeExecutor,
+  opts: {
+    improve?: boolean;
+    diff?: string;
+    cfg?: CollaborativeConfig;
+    setupRepo?: (dir: string) => void;
+  } = {}
+): Promise<CollaborativeRunResult> {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ivan-loop-test-'));
+  opts.setupRepo?.(tmp);
+  const diff = opts.diff ?? DIFF;
+  const ex = new CollaborativeExecutor(fake, opts.cfg ?? CFG);
+  return ex.run({
+    taskDescription: 'Add a CLI command to export the report as CSV',
+    executionPath: tmp,
+    learningsRepoPath: tmp,
+    getDiff: () => diff,
+    improve: opts.improve
+  });
+}
+
+/** Writes a package.json declaring a Playwright dev dependency into `dir`. */
+function withPlaywright(dir: string): void {
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ devDependencies: { '@playwright/test': '^1.48.0' } })
+  );
+}
+
+const UI_DIFF =
+  'diff --git a/Button.tsx b/Button.tsx\n@@\n+<button>Go</button>';
+
+describe('CollaborativeExecutor — Phase 4 improvement loop', () => {
+  it('builds in-scope `now` items and surfaces `future` ideas, then ships', async () => {
+    const { fake, counts } = makeFake([
+      'IMPROVEMENT | ux | now | Show a spinner while the export runs\n' +
+        'IMPROVEMENT | feature | future | Support exporting to XLSX as well\n' +
+        'VERDICT: IMPROVE',
+      'VERDICT: SHIP'
+    ]);
+
+    const res = await runLoop(fake, { improve: true });
+
+    assert.equal(
+      counts.productReviews,
+      2,
+      'reviewed twice (improve, then ship)'
+    );
+    assert.equal(
+      counts.applyImprovements,
+      1,
+      'applied the one round of `now` items'
+    );
+    assert.match(
+      counts.applyPrompts[0],
+      /Show a spinner while the export runs/,
+      'apply prompt carried the `now` item'
+    );
+    const surfaced = res.surfacedImprovements;
+    assert.ok(surfaced, 'future ideas were surfaced');
+    assert.match(surfaced, /Support exporting to XLSX/);
+    assert.match(surfaced, /\[feature\]/);
+    // `now` items are implemented, never surfaced as "future".
+    assert.doesNotMatch(surfaced, /Show a spinner/);
+  });
+
+  it('ships immediately when the reviewer finds nothing in scope', async () => {
+    const { fake, counts } = makeFake(['Looks complete.\nVERDICT: SHIP']);
+
+    const res = await runLoop(fake, { improve: true });
+
+    assert.equal(counts.productReviews, 1);
+    assert.equal(counts.applyImprovements, 0, 'nothing applied');
+    assert.equal(res.surfacedImprovements, undefined, 'nothing surfaced');
+  });
+
+  it('stops at maxImprovementRounds even if the reviewer keeps finding work', async () => {
+    // Descriptions are deliberately dissimilar so stuck-detection does not fire
+    // first — we want the safety cap to be the thing that stops the loop.
+    const { fake, counts } = makeFake([
+      'IMPROVEMENT | ux | now | Improve the wording of validation errors\nVERDICT: IMPROVE',
+      'IMPROVEMENT | feature | now | Add keyboard shortcuts for list navigation\nVERDICT: IMPROVE',
+      'IMPROVEMENT | ux | now | Persist the selected filters across page reloads\nVERDICT: IMPROVE',
+      'IMPROVEMENT | ux | now | A fourth improvement that should never be reached\nVERDICT: IMPROVE'
+    ]);
+
+    await runLoop(fake, {
+      improve: true,
+      cfg: { ...CFG, maxImprovementRounds: 3 }
+    });
+
+    assert.equal(counts.productReviews, 3, 'capped at 3 review rounds');
+    assert.equal(counts.applyImprovements, 3, 'applied each of the 3 rounds');
+  });
+
+  it('stops when the same `now` improvement resurfaces (stuck-detection)', async () => {
+    const repeated =
+      'IMPROVEMENT | ux | now | Add an empty state to the dashboard list\nVERDICT: IMPROVE';
+    const { fake, counts } = makeFake([repeated, repeated, repeated]);
+
+    await runLoop(fake, {
+      improve: true,
+      cfg: { ...CFG, maxImprovementRounds: 5 }
+    });
+
+    assert.equal(
+      counts.productReviews,
+      2,
+      'reviewed, saw the repeat, then stopped'
+    );
+    assert.equal(
+      counts.applyImprovements,
+      1,
+      'applied once; did not re-apply the identical item'
+    );
+  });
+
+  it('skips the improvement loop entirely when there is no diff', async () => {
+    const { fake, counts } = makeFake(['VERDICT: SHIP']);
+
+    const res = await runLoop(fake, { improve: true, diff: '' });
+
+    assert.equal(
+      counts.productReviews,
+      0,
+      'no product review on an empty diff'
+    );
+    assert.equal(res.surfacedImprovements, undefined);
+  });
+
+  it('does not run Phase 4 at all in expert mode (improve falsy)', async () => {
+    const { fake, counts } = makeFake([
+      'IMPROVEMENT | ux | now | Should never be seen\nVERDICT: IMPROVE'
+    ]);
+
+    const res = await runLoop(fake, { improve: false });
+
+    assert.equal(
+      counts.productReviews,
+      0,
+      'improvement loop is loop-mode only'
+    );
+    assert.equal(counts.applyImprovements, 0);
+    assert.equal(res.surfacedImprovements, undefined);
+    // Expert phases still ran: design review + code review used the architect.
+    assert.ok(counts.architectReviews >= 2, 'expert design + code review ran');
+  });
+});
+
+describe('CollaborativeExecutor — Playwright UX probe', () => {
+  it('activates when enabled + Playwright present + UI diff: probe prompt + command execution', async () => {
+    const { fake, counts } = makeFake(['VERDICT: SHIP']);
+
+    await runLoop(fake, {
+      improve: true,
+      diff: UI_DIFF,
+      cfg: {
+        ...CFG,
+        uxProbe: {
+          enabled: true,
+          startCommand: 'npm run dev',
+          url: 'http://localhost:3000'
+        }
+      },
+      setupRepo: withPlaywright
+    });
+
+    assert.match(
+      counts.lastProductPrompt,
+      /Playwright/,
+      'probe block injected'
+    );
+    assert.match(
+      counts.lastProductPrompt,
+      /npm run dev/,
+      'start command included'
+    );
+    assert.equal(
+      counts.lastProductPermission,
+      'bypassPermissions',
+      'probe turn can execute (still read-only for source)'
+    );
+  });
+
+  it('stays a static review (plan mode) when the probe is disabled', async () => {
+    const { fake, counts } = makeFake(['VERDICT: SHIP']);
+
+    await runLoop(fake, {
+      improve: true,
+      diff: UI_DIFF,
+      // uxProbe.enabled defaults to false in CFG
+      setupRepo: withPlaywright
+    });
+
+    assert.doesNotMatch(counts.lastProductPrompt, /Playwright/);
+    assert.equal(counts.lastProductPermission, 'plan');
+  });
+
+  it('does not activate when enabled but the repo lacks Playwright', async () => {
+    const { fake, counts } = makeFake(['VERDICT: SHIP']);
+
+    await runLoop(fake, {
+      improve: true,
+      diff: UI_DIFF,
+      cfg: { ...CFG, uxProbe: { enabled: true, startCommand: 'npm run dev' } }
+      // no setupRepo → no package.json / playwright config in the worktree
+    });
+
+    assert.doesNotMatch(counts.lastProductPrompt, /Playwright/);
+    assert.equal(counts.lastProductPermission, 'plan');
+  });
+
+  it('does not activate for a backend-only diff even with Playwright present', async () => {
+    const { fake, counts } = makeFake(['VERDICT: SHIP']);
+
+    await runLoop(fake, {
+      improve: true,
+      diff: DIFF, // touches `f`, no UI extension
+      cfg: { ...CFG, uxProbe: { enabled: true, startCommand: 'npm run dev' } },
+      setupRepo: withPlaywright
+    });
+
+    assert.doesNotMatch(counts.lastProductPrompt, /Playwright/);
+    assert.equal(counts.lastProductPermission, 'plan');
+  });
+});
+
+describe('CollaborativeExecutor.parseImprovements', () => {
+  // parseImprovements is private; access it directly for focused edge-case
+  // coverage of the reviewer's output contract.
+  const parse = (
+    msg: string
+  ): { now: string[]; future: string[]; ship: boolean } =>
+    (
+      new CollaborativeExecutor(makeFake([]).fake, CFG) as unknown as {
+        parseImprovements: (m: string) => {
+          now: string[];
+          future: string[];
+          ship: boolean;
+        };
+      }
+    ).parseImprovements(msg);
+
+  it('splits now/future and reads the verdict', () => {
+    const r = parse(
+      'IMPROVEMENT | feature | now | Add a --json flag\n' +
+        'IMPROVEMENT | ux | future | Add pagination\n' +
+        'VERDICT: IMPROVE'
+    );
+    assert.deepEqual(r.now, ['- [feature] Add a --json flag']);
+    assert.deepEqual(r.future, ['- [ux] Add pagination']);
+    assert.equal(r.ship, false);
+  });
+
+  it('is case-insensitive and trims trailing whitespace', () => {
+    const r = parse(
+      'improvement |  UX | NOW |  Tidy the help text   \nVERDICT: improve'
+    );
+    assert.deepEqual(r.now, ['- [ux] Tidy the help text']);
+  });
+
+  it('defaults to ship when the verdict is missing and there are no `now` items', () => {
+    assert.equal(parse('Nothing to add here.').ship, true);
+  });
+
+  it('does not ship on a missing verdict when `now` items exist', () => {
+    const r = parse('IMPROVEMENT | ux | now | Improve the error message');
+    assert.equal(r.ship, false);
+    assert.deepEqual(r.now, ['- [ux] Improve the error message']);
+  });
+
+  it('still surfaces `future` items even when the reviewer ships', () => {
+    const r = parse(
+      'IMPROVEMENT | feature | future | A big follow-up idea\nVERDICT: SHIP'
+    );
+    assert.equal(r.ship, true);
+    assert.deepEqual(r.future, ['- [feature] A big follow-up idea']);
+  });
+});

--- a/src/services/collaborative-executor.ts
+++ b/src/services/collaborative-executor.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import chalk from 'chalk';
 import type { IClaudeExecutor, TurnResult } from './executor-factory.js';
 import type { CollaborativeConfig } from '../config.js';
@@ -23,6 +25,18 @@ Calibrate your verdict deliberately, because each REVISE costs a full revision r
 - If the work is good enough to proceed and your remaining concerns are minor, stylistic, speculative, or better handled later, use APPROVE_WITH_NITS instead of spending another round.
 - Iterate as many rounds as the problem genuinely needs, but do not manufacture concerns to keep iterating. When a design is sound, approve it.`;
 
+/**
+ * The product-reviewer persona for "loop" mode (Phase 4). A separate, skeptical
+ * evaluator — an independent reviewer critiques far better than a generator
+ * grading its own work — that runs AFTER the implementation is correct and asks
+ * the different question: what would make this genuinely better for the user, in
+ * features and in UX? It proposes concrete improvements and is disciplined about
+ * scope, keeping the PR tight and deferring larger ideas to follow-ups.
+ */
+const PRODUCT_REVIEWER_SYSTEM_PROMPT = `You are a product-minded staff engineer pairing with a designer, reviewing a teammate's completed and correct implementation. The code already works and passed correctness review — your job is NOT to re-check correctness. Your job is to raise the bar: what would make this meaningfully better for the user, in features and in UX?
+
+You care about the user's actual experience: complete features, graceful error / empty / loading states, sensible defaults, clear feedback, discoverability, accessibility, and consistency with the rest of the product. You propose concrete, specific improvements — never vague "polish it" notes — and you are honest about scope, keeping the current change tight and deferring anything large or risky to a follow-up. You may read and inspect the codebase, but never modify it.`;
+
 const MAX_DIFF_CHARS = 60000;
 
 export interface CollaborativeRunParams {
@@ -39,6 +53,12 @@ export interface CollaborativeRunParams {
   getDiff: () => string;
   /** Optional session to resume so multi-task / single-PR runs keep context. */
   incomingSessionId?: string;
+  /**
+   * When true ("loop" mode), run the Phase 4 improvement loop after the
+   * correctness review: a product-minded reviewer pushes for feature/UX gains,
+   * in-scope ones are implemented, and larger ideas are surfaced to the caller.
+   */
+  improve?: boolean;
 }
 
 /**
@@ -62,6 +82,13 @@ export interface CollaborativeRunResult extends TurnResult {
    * (e.g. in the PR body) without aborting the autonomous run.
    */
   unresolvedConcerns?: string;
+  /**
+   * Present in "loop" mode when the Phase 4 product reviewer proposed
+   * improvements it judged out of scope for this change (larger features or
+   * riskier UX work). A newline-separated bullet list, surfaced to the human in
+   * the PR body as "Future improvements" — proposed, never auto-built.
+   */
+  surfacedImprovements?: string;
 }
 
 /**
@@ -83,7 +110,8 @@ export class CollaborativeExecutor {
       executionPath,
       learningsRepoPath,
       getDiff,
-      incomingSessionId
+      incomingSessionId,
+      improve
     } = params;
 
     const transcript: string[] = [];
@@ -104,10 +132,16 @@ export class CollaborativeExecutor {
 
     let implSession = incomingSessionId;
     let architectSession: string | undefined;
+    // Separate session for the Phase 4 product reviewer ("loop" mode). Kept
+    // distinct from the architect so its persona/model don't bleed together.
+    let productSession: string | undefined;
     // Set when a phase proceeds despite an unresolved blocking (REVISE) verdict
     // (round cap or stuck-detection). Surfaced to the caller so the reviewer
     // sees what the architect rejected, without aborting the autonomous run.
     let unresolvedConcerns: string | undefined;
+    // Accumulated in Phase 4 ("loop" mode): out-of-scope feature/UX ideas the
+    // product reviewer proposed but did not build, surfaced to the human.
+    let surfacedImprovements: string | undefined;
 
     // ----- Phase 1: design dialogue -----
     // The number of rounds is not fixed: the loop ends as soon as the architect
@@ -285,11 +319,116 @@ export class CollaborativeExecutor {
       record(`Implementer — revisions (round ${round})`, latestImplLog);
     }
 
+    // ----- Phase 4: improvement loop ("loop" mode only) -----
+    // The implementation is correct; now a product-minded reviewer looks at the
+    // original request and the built diff and asks what would make it better in
+    // features and UX. In-scope improvements are implemented; larger ideas are
+    // surfaced. Same dynamic termination: stops when the reviewer ships, finds
+    // no in-scope improvements, repeats itself, or hits the safety cap.
+    if (improve) {
+      const surfaced: string[] = [];
+      let previousNow: string | undefined;
+      this.header('🔁 Loop mode: reviewing for feature & UX improvements');
+
+      // Visual UX probe: when enabled and the worktree supports Playwright and
+      // the change touches UI, the reviewer is told to run the app and inspect
+      // the rendered result — and its turn is granted command execution (still
+      // read-only for source) so it can actually start a dev server + Playwright.
+      const uxProbe =
+        this.config.uxProbe.enabled &&
+        this.repoSupportsPlaywright(executionPath) &&
+        this.diffTouchesUi(getDiff())
+          ? this.config.uxProbe
+          : undefined;
+      if (uxProbe) {
+        console.log(
+          chalk.gray(
+            '🖼️  Playwright detected — the product reviewer will run the app and inspect the rendered UI.'
+          )
+        );
+      }
+
+      for (let round = 1; round <= this.config.maxImprovementRounds; round++) {
+        const diff = this.truncateDiff(getDiff());
+        if (!diff.trim()) {
+          console.log(
+            chalk.yellow(
+              '⚠️  No changes to improve; skipping improvement loop.'
+            )
+          );
+          break;
+        }
+
+        this.header(`🔭 Product review — improvements (round ${round})`);
+        const review = await this.turn(
+          this.improvementReviewPrompt(taskDescription, diff, brief, uxProbe),
+          executionPath,
+          {
+            sessionId: productSession,
+            // A UX probe needs to execute (start the app, drive Playwright), so
+            // it runs with command execution allowed; readOnly still blocks all
+            // source edits. Otherwise the reviewer only inspects, under 'plan'.
+            permissionMode: uxProbe ? 'bypassPermissions' : 'plan',
+            readOnly: true,
+            systemPrompt: PRODUCT_REVIEWER_SYSTEM_PROMPT,
+            model: this.config.productModel
+          },
+          (r) => (productSession = r.sessionId)
+        );
+        record(`Product review — improvements (round ${round})`, review);
+
+        const { now, future, ship } = this.parseImprovements(review);
+        for (const f of future) if (!surfaced.includes(f)) surfaced.push(f);
+
+        if (ship || now.length === 0) {
+          console.log(
+            chalk.green(
+              '✅ Product review: nothing further worth building in scope.'
+            )
+          );
+          break;
+        }
+
+        const nowSignature = now.join('\n');
+        if (previousNow && this.isRepeatConcern(previousNow, nowSignature)) {
+          console.log(
+            chalk.yellow(
+              '⚠️  The same improvements resurfaced; the loop is not converging. Proceeding.'
+            )
+          );
+          break;
+        }
+        previousNow = nowSignature;
+
+        this.header(`🔨 Implementer — applying improvements (round ${round})`);
+        latestImplLog = await this.turn(
+          this.applyImprovementsPrompt(now),
+          executionPath,
+          { sessionId: implSession, permissionMode: 'bypassPermissions' },
+          (r) => (implSession = r.sessionId)
+        );
+        record(
+          `Implementer — applied improvements (round ${round})`,
+          latestImplLog
+        );
+
+        if (round === this.config.maxImprovementRounds) {
+          console.log(
+            chalk.yellow(
+              `⚠️  Improvement loop reached its safety cap (${round} round(s)); proceeding.`
+            )
+          );
+        }
+      }
+      if (surfaced.length > 0) surfacedImprovements = surfaced.join('\n');
+    }
+
     return {
       log: transcript.join('\n'),
       lastMessage: latestImplLog,
       sessionId: implSession || '',
-      ...(unresolvedConcerns ? { unresolvedConcerns } : {})
+      ...(unresolvedConcerns ? { unresolvedConcerns } : {}),
+      ...(surfacedImprovements ? { surfacedImprovements } : {})
     };
   }
 
@@ -353,6 +492,41 @@ export class CollaborativeExecutor {
       else decision = 'approve';
     }
     return { decision, notes: message };
+  }
+
+  /**
+   * Parse the Phase 4 product reviewer's output. Improvements are emitted as
+   * pipe-separated lines — `IMPROVEMENT | <feature|ux> | <now|future> | <text>`
+   * — and the message ends with `VERDICT: SHIP` or `VERDICT: IMPROVE`.
+   *
+   * `now` items are implemented this round; `future` items are surfaced to the
+   * human. A missing/malformed verdict defaults to SHIP when there are no `now`
+   * items: unlike the correctness gate, the improvement loop biases toward
+   * stopping (never invent work to keep looping).
+   */
+  private parseImprovements(message: string): {
+    now: string[];
+    future: string[];
+    ship: boolean;
+  } {
+    const now: string[] = [];
+    const future: string[] = [];
+    const lineRe =
+      /^\s*IMPROVEMENT\s*\|\s*(feature|ux)\s*\|\s*(now|future)\s*\|\s*(.+?)\s*$/i;
+    for (const line of message.split('\n')) {
+      const m = line.match(lineRe);
+      if (!m) continue;
+      const category = m[1].toLowerCase();
+      const scope = m[2].toLowerCase();
+      const entry = `- [${category}] ${m[3].trim()}`;
+      if (scope === 'now') now.push(entry);
+      else future.push(entry);
+    }
+    const verdict = message.match(/VERDICT:\s*(SHIP|IMPROVE)/i);
+    const ship = verdict
+      ? verdict[1].toUpperCase() === 'SHIP'
+      : now.length === 0;
+    return { now, future, ship };
   }
 
   /**
@@ -476,5 +650,106 @@ Apply these changes to the implementation now.`;
 ${notes}
 
 Apply these minor improvements now where reasonable. Keep the changes small and focused — do not undertake larger rework.`;
+  }
+
+  private improvementReviewPrompt(
+    task: string,
+    diff: string,
+    brief: string,
+    uxProbe?: { startCommand?: string; url?: string }
+  ): string {
+    return `The implementation below is CORRECT and already passed code review. Your job now is different: figure out what would make it genuinely BETTER for the user — in features and in UX — relative to the original request.
+
+ORIGINAL REQUEST:
+${task}
+${this.briefBlock(brief)}
+IMPLEMENTED DIFF:
+${diff}
+${this.uxProbeBlock(uxProbe)}
+Inspect the codebase read-only to ground yourself in how it actually behaves. Look concretely for:
+- Feature completeness: capabilities the request implies but the diff doesn't deliver; obvious gaps a user hits immediately.
+- UX quality: error / empty / loading states, input validation and feedback, sensible defaults, discoverability, consistency with existing patterns, accessibility, and the clarity of messages and output.
+
+Be specific — no vague "polish it" notes. For each improvement, judge its scope honestly:
+- \`now\`    = small, safe, and clearly within the original request's intent. These get implemented in this change.
+- \`future\` = larger, riskier, or scope-broadening. These get surfaced to the human, not built.
+When in doubt, choose \`future\` — keep this change tight.
+
+List each improvement on its own line, in EXACTLY this pipe-separated format (nothing else on the line):
+IMPROVEMENT | feature | now | <one concrete improvement>
+IMPROVEMENT | ux | future | <one concrete improvement>
+
+If nothing is worth changing, list no IMPROVEMENT lines.
+
+End your message with exactly one line, nothing after it — one of:
+VERDICT: IMPROVE   (you listed at least one \`now\` improvement to apply this round)
+VERDICT: SHIP      (no \`now\` improvements remain — the work is ready to ship)`;
+  }
+
+  private applyImprovementsPrompt(now: string[]): string {
+    return `A product reviewer identified these in-scope improvements to apply to your implementation now. Implement them fully, keeping each change focused, consistent with the existing code, and faithful to the team's conventions. Do NOT undertake large rework or broaden scope beyond these items:
+
+${now.join('\n')}`;
+  }
+
+  /**
+   * Instruction block that turns the UX review from "reason about the code" into
+   * "observe the rendered UI." Injected only when the visual UX probe is active.
+   * Screenshots come back into context for free because Read renders PNGs.
+   */
+  private uxProbeBlock(uxProbe?: {
+    startCommand?: string;
+    url?: string;
+  }): string {
+    if (!uxProbe) return '';
+    const start = uxProbe.startCommand
+      ? `Start the app in the background with \`${uxProbe.startCommand}\``
+      : 'Start the app in the background (infer the dev command from package.json scripts, e.g. `npm run dev`)';
+    const ready = uxProbe.url
+      ? `, waiting until it is ready at ${uxProbe.url}`
+      : '';
+    return `
+This repository has Playwright and this change appears to affect a user-facing UI. Before judging UX, OBSERVE the rendered result rather than only reasoning about the code:
+1. ${start}${ready}. Use a timeout so a hung start can't stall you.
+2. Drive Playwright to the screens this change affects, save screenshots to files in a temp directory, then Read those image files so you can see the actual rendered UI — real error / empty / loading states, layout, spacing, alignment, and interactions.
+3. Base your UX critique on what you actually see, calling out anything that looks broken, misaligned, or confusing when rendered.
+4. When finished, kill the app/server you started. If Playwright's browsers aren't installed, run \`npx playwright install\` once. If you still cannot run it, fall back to a static (code-only) review and say so explicitly.
+Do NOT modify any source files while doing this.
+`;
+  }
+
+  /**
+   * Whether the worktree can run Playwright — a Playwright config file or a
+   * playwright dependency in package.json. Best-effort and never throws.
+   */
+  private repoSupportsPlaywright(executionPath: string): boolean {
+    try {
+      const configNames = [
+        'playwright.config.ts',
+        'playwright.config.js',
+        'playwright.config.mjs',
+        'playwright.config.cjs'
+      ];
+      if (configNames.some((n) => fs.existsSync(path.join(executionPath, n)))) {
+        return true;
+      }
+      const pkgPath = path.join(executionPath, 'package.json');
+      if (fs.existsSync(pkgPath)) {
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+        const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+        if (deps['@playwright/test'] || deps['playwright']) return true;
+      }
+    } catch {
+      // Malformed package.json or unreadable path — treat as unsupported.
+    }
+    return false;
+  }
+
+  /**
+   * Heuristic: does the diff touch user-facing UI files? Gates the UX probe so we
+   * don't spin up a dev server for a backend-only change.
+   */
+  private diffTouchesUi(diff: string): boolean {
+    return /\.(tsx|jsx|vue|svelte|astro|css|scss|sass|less|html)\b/i.test(diff);
   }
 }

--- a/src/services/task-executor.ts
+++ b/src/services/task-executor.ts
@@ -71,16 +71,47 @@ export class TaskExecutor {
   }
 
   /**
+   * Appends a "Future improvements" section to a PR body in "loop" mode. These
+   * are feature/UX ideas the product reviewer judged out of scope and did NOT
+   * build — surfaced for the human to consider, never auto-applied.
+   */
+  private appendImprovements(body: string, improvements: string[]): string {
+    const valid = improvements.filter((c) => c && c.trim());
+    if (valid.length === 0) return body;
+
+    const MAX_IMPROVEMENT_LENGTH = 4000;
+    const sections = valid.map((imp) => {
+      const cleaned = imp.trim();
+      return cleaned.length > MAX_IMPROVEMENT_LENGTH
+        ? `${cleaned.slice(0, MAX_IMPROVEMENT_LENGTH)}\n\n…(truncated)`
+        : cleaned;
+    });
+
+    const heading =
+      '## 🔭 Future improvements\n' +
+      "_Surfaced by Ivan's loop mode — higher-value feature/UX ideas that were out of scope for this PR. Proposed, not implemented; here for your consideration._";
+
+    return `${body}\n\n---\n\n${heading}\n\n${sections.join('\n\n')}`;
+  }
+
+  /**
    * Runs the implementation for a task, branching on execution mode:
    * - 'simple': a single one-shot hand-off to Claude Code (default)
    * - 'expert': a collaborative architect↔implementer loop informed by learnings
+   * - 'loop': everything 'expert' does, then a product-review improvement loop
    */
   private async runImplementation(
     taskWithInstructions: string,
     executionPath: string,
     sessionId?: string
-  ): Promise<TurnResult & Pick<CollaborativeRunResult, 'unresolvedConcerns'>> {
-    if (this.executionMode === 'expert') {
+  ): Promise<
+    TurnResult &
+      Pick<
+        CollaborativeRunResult,
+        'unresolvedConcerns' | 'surfacedImprovements'
+      >
+  > {
+    if (this.executionMode === 'expert' || this.executionMode === 'loop') {
       const collaborative = new CollaborativeExecutor(
         this.getClaudeExecutor(),
         this.configManager.getCollaborativeConfig()
@@ -95,7 +126,8 @@ export class TaskExecutor {
           }
           return this.gitManager.getDiff();
         },
-        incomingSessionId: sessionId
+        incomingSessionId: sessionId,
+        improve: this.executionMode === 'loop'
       });
     }
     return this.getClaudeExecutor().executeTask(
@@ -133,6 +165,14 @@ export class TaskExecutor {
           chalk.magenta.bold(
             '🧠 Expert mode: Ivan will act as a principal engineer, ' +
               'critiquing the design and implementation across rounds.'
+          )
+        );
+      } else if (mode === 'loop') {
+        console.log(
+          chalk.magenta.bold(
+            '🔁 Loop mode: Ivan critiques design and implementation like a ' +
+              'principal engineer, then loops as a product reviewer — pushing ' +
+              'for feature/UX improvements and surfacing larger ideas on the PR.'
           )
         );
       }
@@ -688,9 +728,12 @@ export class TaskExecutor {
       if (!this.gitManager) {
         throw new Error('GitManager not initialized');
       }
-      const prBody = this.prependConcerns(
-        body,
-        result.unresolvedConcerns ? [result.unresolvedConcerns] : []
+      const prBody = this.appendImprovements(
+        this.prependConcerns(
+          body,
+          result.unresolvedConcerns ? [result.unresolvedConcerns] : []
+        ),
+        result.surfacedImprovements ? [result.surfacedImprovements] : []
       );
       const prUrl = await this.gitManager.createPullRequest(title, prBody);
       if (spinner) spinner.succeed(`Pull request created: ${prUrl}`);
@@ -752,6 +795,7 @@ export class TaskExecutor {
     let branchName: string | null = null;
     let sessionId: string | undefined;
     const unresolvedConcerns: string[] = [];
+    const surfacedImprovements: string[] = [];
 
     try {
       if (!this.gitManager) {
@@ -822,6 +866,11 @@ export class TaskExecutor {
         if (result.unresolvedConcerns) {
           unresolvedConcerns.push(
             `**${task.description}**\n\n${result.unresolvedConcerns}`
+          );
+        }
+        if (result.surfacedImprovements) {
+          surfacedImprovements.push(
+            `**${task.description}**\n\n${result.surfacedImprovements}`
           );
         }
         if (spinner) {
@@ -1021,7 +1070,10 @@ export class TaskExecutor {
       if (spinner) spinner.succeed('PR description generated');
 
       if (!quiet) spinner = ora('Creating pull request...').start();
-      const prBody = this.prependConcerns(body, unresolvedConcerns);
+      const prBody = this.appendImprovements(
+        this.prependConcerns(body, unresolvedConcerns),
+        surfacedImprovements
+      );
       const prUrl = await this.gitManager.createPullRequest(title, prBody);
       if (spinner) spinner.succeed(`Pull request created: ${prUrl}`);
 

--- a/src/types/non-interactive-config.ts
+++ b/src/types/non-interactive-config.ts
@@ -1,4 +1,4 @@
-export type ExecutionMode = 'simple' | 'expert';
+export type ExecutionMode = 'simple' | 'expert' | 'loop';
 
 export interface NonInteractiveConfig {
   /**
@@ -48,6 +48,9 @@ export interface NonInteractiveConfig {
    * Execution mode.
    * - 'simple': one-shot hand-off to Claude Code (default)
    * - 'expert': collaborative architect↔implementer loop informed by learnings
+   * - 'loop': everything 'expert' does, then an improvement loop where a
+   *   product-minded reviewer pushes for feature/UX gains within scope and
+   *   surfaces larger ideas to the PR (see CollaborativeExecutor Phase 4)
    */
   mode?: ExecutionMode;
 }


### PR DESCRIPTION
## What

Adds a third execution mode, **`--mode loop`**, that extends expert mode with an improvement loop. Where expert mode is a *correctness gate* ("is this right?"), loop mode adds the next question — *"is this good?"* — and iterates on feature/UX quality.

```
--mode simple   one-shot hand-off
--mode expert   correctness gate (design → implement → review)   [unchanged]
--mode loop     expert baseline, then a product-review improvement loop
```

Loop is a **superset of expert**: it runs the full expert collaboration first (so improvements build on a vetted baseline), then a **Phase 4** where a separate, product-minded reviewer looks at the original request + the built diff and proposes concrete improvements.

## How it works

- **Separate product-reviewer persona** on the architect model (an independent skeptical evaluator critiques far better than a generator grading its own work).
- Each improvement is tagged `now` (small, safe, in-scope → **implemented that round**) or `future` (larger/scope-broadening → **surfaced, not built**), and `feature` / `ux`.
- `future` ideas accumulate into a **"🔭 Future improvements"** section appended to the PR body — proposed, never auto-applied — so the diff stays reviewable.
- **Fast convergence** (reuses expert's machinery): stops on a `SHIP` verdict, when no in-scope items remain, on stuck-detection (repeated identical items), on an empty diff, or at the `maxImprovementRounds` safety cap.

## Visual UX probe (opt-in, off by default)

By default the reviewer judges UX from the code. Set `collaborative.uxProbe.enabled` and — when the worktree has **Playwright** *and* the change touches UI — the reviewer instead runs the app, drives Playwright to the affected screens, and **reads back screenshots** to critique the *rendered* result. That review turn is granted command execution (`bypassPermissions`) but stays **read-only for source** (`readOnly` still blocks all edits); it falls back to a static review if it can't launch.

```jsonc
"collaborative": {
  "productModel": "claude-opus-4-8",   // defaults to architectModel
  "maxImprovementRounds": 3,
  "uxProbe": { "enabled": false, "startCommand": "npm run dev", "url": "http://localhost:3000" }
}
```

## Grounding

Follows Anthropic's evaluator-optimizer / loop-engineering guidance: independent evaluator, **concrete** UX criteria (not "polish it"), real diff/codebase as ground truth, durable artifacts (future ideas persisted on the PR), and a bias toward stopping (correctness is the usual bar).

## Tests

15 fully-offline unit tests via `npm run test:unit` (`node:test` + tsx), driving the real `CollaborativeExecutor` through a fake executor — no Claude/git/network:
- Phase 4 termination matrix: build+surface then ship, immediate ship, round cap, stuck-detection, empty-diff skip, and `improve:false` (Phase 4 must not run in expert mode).
- `parseImprovements` edge cases.
- UX-probe activation: prompt block + `bypassPermissions` when enabled+Playwright+UI-diff; stays `plan`/static otherwise (disabled, no Playwright, or backend-only diff).

`typecheck` / `lint` / `prettier` / `build` all clean.

## Notes / tradeoffs

- **Scope discipline:** the reviewer defaults ambiguous items to `future`, and `now` items are instructed not to undertake large rework — so a loop run stays a reviewable PR.
- `now` improvements are applied within the (architect-vetted) implementer session but are not re-run through the architect's *correctness* gate — a reasonable v1 tradeoff; a lightweight re-check could be a follow-up.
- The probe's actual browser run is exercised only at the prompt/permission level in tests (kept offline); a live `--mode loop` run with `uxProbe.enabled` on a small web repo is the recommended manual shakeout.

Files: `collaborative-executor.ts` (persona, Phase 4, parser, UX probe), `config.ts` (uxProbe + productModel/maxImprovementRounds), `task-executor.ts` (threading + PR-body append + banner), `index.ts` (`resolveMode`/help), `non-interactive-config.ts` (`ExecutionMode`), README, tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **loop** mode for more iterative runs, including an extra improvement pass before finalizing changes.
  * PR summaries can now include a **Future improvements** section with suggested follow-up ideas.

* **Bug Fixes**
  * Improved handling of review feedback so only actionable items are applied automatically.
  * Added safeguards to stop repeated improvement cycles and prevent endless loops.

* **Tests**
  * Expanded automated coverage for loop mode, improvement parsing, and UX probe behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->