### PR TITLE
Pre-PR self code review: Claude Code reviews its own changes before opening a PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ That's it. Ivan will:
 
 1. 🧩 **Break down** your request into manageable, PR-ready tasks
 2. 🌿 **Branch & implement** each one using Claude Code
-3. ✍️ **Write** conventional commit messages and a detailed PR description
-4. 📬 **Open the PR** with context-specific review instructions
+3. 🤖 **Self-review** the change with Claude Code — against your team's lessons and engineering best practices — and quietly fix what it finds
+4. ✍️ **Write** conventional commit messages and a detailed PR description
+5. 📬 **Open the PR** with context-specific review instructions
 
 Want Ivan to think harder? Add one flag:
 
@@ -98,6 +99,33 @@ In **Expert mode**, Ivan splits into two minds. The **Implementer** writes the c
     "architectModel": "claude-opus-4-8", // the reviewer's brain
     "maxDesignRounds": 5,                 // max design back-and-forths before building
     "maxReviewRounds": 3                  // max code-review back-and-forths before shipping
+  }
+}
+```
+
+---
+
+## 🤖 Self-review before every PR
+
+Before Ivan opens a pull request, it does what a careful engineer does last: **asks Claude Code to review its own diff — and fixes what it finds.** This runs in *every* mode (simple, expert, loop), so even a one-shot `simple` run gets a review pass before it reaches you.
+
+A fresh, read-only reviewer session critiques the change, then the implementer session silently applies the fixes — folded into the same commit (or a follow-up commit in single-PR runs), so your PR arrives already cleaned up. The review is grounded in:
+
+- 🧠 **Your team's institutional knowledge** — the same learnings store Expert mode uses (see below), injected into the review.
+- 📐 **Engineering best practices** — an explicit bar: correctness & edge cases, security, *follow the existing patterns in the codebase*, *reuse/extract instead of reinventing*, don't over-engineer, and keep it maintainable without piling up tech debt.
+
+It's on by default and conservative — it only changes code when the review finds something genuinely worth fixing, and treats an unclear review as "ship it." Turn it off per-run or globally:
+
+```bash
+ivan "Fix the timezone bug" --no-self-review     # skip it for this run
+```
+
+```jsonc
+// ~/.ivan/config.json
+{
+  "selfReview": {
+    "enabled": true,               // set false to disable globally
+    "model": "claude-opus-4-8"     // optional: a stronger model for the reviewer (defaults to your implementer model)
   }
 }
 ```
@@ -225,6 +253,7 @@ ivan config-blocked-tools     # block specific tools (least-privilege by repo)
 ivan                          # interactive: Ivan asks what to build
 ivan "task description"       # headless: run a task directly
 ivan --mode expert "task"     # collaborative architect ↔ implementer loop
+ivan --no-self-review "task"  # skip the pre-PR Claude Code self review
 ivan --base-branch dev "task" # branch work off a specific local base branch
 ivan -c config.json           # run from a JSON config (CI-friendly)
 ivan -c '{"tasks":["A","B"],"mode":"expert"}'   # inline JSON config
@@ -284,9 +313,9 @@ Open http://localhost:3000 to watch jobs, task progress, execution logs, and PR 
 **Build workflow**
 
 ```
-request ─▶ task breakdown ─▶ branch ─▶ implement ─▶ smart commit ─▶ PR
-                                  │                                    │
-                          (expert mode: design + review rounds)  (optional: wait & auto-address)
+request ─▶ task breakdown ─▶ branch ─▶ implement ─▶ self-review + fix ─▶ smart commit ─▶ PR
+                                  │                                                        │
+                          (expert mode: design + review rounds)          (optional: wait & auto-address)
 ```
 
 **Address workflow** — finds unresolved inline comments via the GitHub GraphQL API, implements each fix, replies with the fixing commit, and adds context-specific review instructions.
@@ -303,6 +332,7 @@ ivan/
 │   ├── services/
 │   │   ├── task-executor.ts          # orchestrates the build workflow (simple | expert)
 │   │   ├── collaborative-executor.ts # the architect ↔ implementer loop (expert mode)
+│   │   ├── self-review-executor.ts   # pre-PR Claude Code self review + fixes
 │   │   ├── claude-executor.ts        # Claude Code SDK driver
 │   │   ├── claude-cli-executor.ts    # Claude Code CLI driver (Claude Max)
 │   │   ├── address-executor.ts       # PR comment addressing workflow

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "typecheck": "tsc --noEmit",
+    "test:unit": "tsx --test src/services/*.test.ts",
     "test": "npm run build && node --experimental-vm-modules ./node_modules/jest/bin/jest.js --runInBand --config jest.config.cjs",
     "test:e2e:learnings": "node scripts/test-learnings-e2e.mjs",
     "prepare": "npm run build && git config core.hooksPath .githooks"

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,12 +24,26 @@ interface Config {
     maxDesignRounds?: number;
     maxReviewRounds?: number;
   };
+  selfReview?: {
+    enabled?: boolean;
+    model?: string;
+  };
 }
 
 export interface CollaborativeConfig {
   architectModel: string;
   maxDesignRounds: number;
   maxReviewRounds: number;
+}
+
+export interface SelfReviewConfig {
+  /** Whether Ivan runs a Claude Code code review (and applies fixes) before opening a PR. */
+  enabled: boolean;
+  /**
+   * Optional model override for the reviewer turn. Defaults to the configured
+   * implementer model; set a stronger model here for a more rigorous review.
+   */
+  model?: string;
 }
 
 export class ConfigManager {
@@ -742,6 +756,20 @@ export class ConfigManager {
       architectModel: c?.architectModel?.trim() || 'claude-opus-4-8',
       maxDesignRounds: sanitizeRounds(c?.maxDesignRounds, 5),
       maxReviewRounds: sanitizeRounds(c?.maxReviewRounds, 3)
+    };
+  }
+
+  /**
+   * Settings for the pre-PR self code review, where Ivan asks Claude Code to
+   * review its own changes (grounded in the team's learnings and engineering
+   * best practices) and silently apply fixes before opening the pull request.
+   * Enabled by default; opt out with `--no-self-review` or `selfReview.enabled`.
+   */
+  getSelfReviewConfig(): SelfReviewConfig {
+    const sr = this.getConfig()?.selfReview;
+    return {
+      enabled: sr?.enabled !== false,
+      model: sr?.model?.trim() || undefined
     };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,10 @@ program
   .option(
     '--mode <mode>',
     'Execution mode: "simple" (one-shot hand-off, default) or "expert" (collaborative architect↔implementer loop informed by learnings)'
+  )
+  .option(
+    '--no-self-review',
+    'Skip the Claude Code code review (and fixes) Ivan runs before opening a PR'
   );
 
 registerLearningsCommands(program);
@@ -711,15 +715,18 @@ async function runNonInteractive(configInput: string): Promise<void> {
     }
 
     // Apply --rewrite-prompt flag if passed on CLI
-    const { rewritePrompt, baseBranch, mode } = program.opts<{
+    const { rewritePrompt, baseBranch, mode, selfReview } = program.opts<{
       rewritePrompt: boolean;
       baseBranch?: string;
       mode?: string;
+      selfReview: boolean;
     }>();
     if (rewritePrompt) config.rewritePrompt = true;
     if (baseBranch) config.baseBranch = baseBranch;
     // CLI --mode overrides the config file; config value wins only if no flag.
     if (mode !== undefined) config.mode = resolveMode(mode);
+    // --no-self-review can only turn it off; otherwise config/default decide.
+    if (selfReview === false) config.selfReview = false;
 
     // Validate config
     if (
@@ -787,11 +794,13 @@ async function main() {
     const {
       rewritePrompt: hasRewriteFlag,
       baseBranch,
-      mode: modeFlag
+      mode: modeFlag,
+      selfReview: selfReviewFlag
     } = program.opts<{
       rewritePrompt: boolean;
       baseBranch?: string;
       mode?: string;
+      selfReview: boolean;
     }>();
     const mode = resolveMode(modeFlag);
 
@@ -884,7 +893,12 @@ async function main() {
       await runMigrations();
 
       const taskExecutor = new TaskExecutor();
-      await taskExecutor.executeWorkflow(hasRewriteFlag, baseBranch, mode);
+      await taskExecutor.executeWorkflow(
+        hasRewriteFlag,
+        baseBranch,
+        mode,
+        selfReviewFlag
+      );
       return;
     }
 

--- a/src/services/self-review-executor.test.ts
+++ b/src/services/self-review-executor.test.ts
@@ -1,0 +1,154 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
+import { SelfReviewExecutor } from './self-review-executor.js';
+import type {
+  IClaudeExecutor,
+  TurnResult,
+  TurnOptions
+} from './executor-factory.js';
+import type { SelfReviewConfig } from '../config.js';
+
+/**
+ * Offline tests for the pre-PR self review via the IClaudeExecutor seam — no
+ * Claude, git, or network. learningsRepoPath is an empty temp dir, so the
+ * learnings query throws (missing store), buildBrief swallows it, and no
+ * embedding/network call is reached.
+ */
+
+const DIFF = 'diff --git a/f b/f\n@@\n+const x = 1;';
+
+interface Call {
+  prompt: string;
+  options: TurnOptions;
+}
+
+function makeFake(reviewText: string): {
+  fake: IClaudeExecutor;
+  calls: Call[];
+} {
+  const calls: Call[] = [];
+  const fake: IClaudeExecutor = {
+    quietMode: true,
+    async executeTurn(
+      prompt: string,
+      _dir: string,
+      options: TurnOptions = {}
+    ): Promise<TurnResult> {
+      calls.push({ prompt, options });
+      // The review turn carries the reviewer system prompt; the fix turn doesn't.
+      const isReview = (options.systemPrompt ?? '').includes(
+        'pre-merge code review'
+      );
+      const text = isReview ? reviewText : 'applied fixes';
+      return {
+        log: text,
+        lastMessage: text,
+        sessionId: options.sessionId ?? 'reviewer'
+      };
+    },
+    async executeTask(): Promise<TurnResult> {
+      return { log: '', lastMessage: '', sessionId: '' };
+    },
+    async generateTaskBreakdown(): Promise<string[]> {
+      return [];
+    },
+    async validateClaudeCodeInstallation(): Promise<void> {}
+  };
+  return { fake, calls };
+}
+
+function runReview(
+  fake: IClaudeExecutor,
+  opts: {
+    reviewText?: string;
+    diff?: string;
+    model?: string;
+    implementerSessionId?: string;
+  } = {}
+) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ivan-selfreview-'));
+  const config: SelfReviewConfig = {
+    enabled: true,
+    ...(opts.model ? { model: opts.model } : {})
+  };
+  const ex = new SelfReviewExecutor(fake, config);
+  return ex.run({
+    diff: opts.diff ?? DIFF,
+    executionPath: tmp,
+    learningsRepoPath: tmp,
+    implementerSessionId: opts.implementerSessionId
+  });
+}
+
+describe('SelfReviewExecutor', () => {
+  it('applies a fix turn when the reviewer requests changes', async () => {
+    const { fake, calls } = makeFake(
+      'Line 12 leaks a file handle; close it.\nVERDICT: CHANGES_REQUESTED'
+    );
+
+    const res = await runReview(fake, { implementerSessionId: 'impl-123' });
+
+    assert.equal(res.changesRequested, true);
+    assert.equal(calls.length, 2, 'review turn + fix turn');
+
+    // Review turn: read-only, plan mode, reviewer persona.
+    assert.equal(calls[0].options.readOnly, true);
+    assert.equal(calls[0].options.permissionMode, 'plan');
+    assert.match(calls[0].options.systemPrompt ?? '', /pre-merge code review/);
+
+    // Fix turn: resumes the implementer session with edit permissions.
+    assert.equal(calls[1].options.permissionMode, 'bypassPermissions');
+    assert.equal(calls[1].options.sessionId, 'impl-123');
+    assert.notEqual(calls[1].options.readOnly, true);
+    assert.match(calls[1].prompt, /asked for the following fixes/);
+  });
+
+  it('does nothing to the code when the reviewer says LGTM', async () => {
+    const { fake, calls } = makeFake('Looks good.\nVERDICT: LGTM');
+
+    const res = await runReview(fake);
+
+    assert.equal(res.changesRequested, false);
+    assert.equal(calls.length, 1, 'review turn only; no fix turn');
+  });
+
+  it('treats a missing/malformed verdict as LGTM (never an unbounded fix)', async () => {
+    const { fake, calls } = makeFake(
+      'I have some vague thoughts but no verdict.'
+    );
+
+    const res = await runReview(fake);
+
+    assert.equal(res.changesRequested, false);
+    assert.equal(calls.length, 1);
+  });
+
+  it('skips the review entirely when there is no diff', async () => {
+    const { fake, calls } = makeFake('VERDICT: CHANGES_REQUESTED');
+
+    const res = await runReview(fake, { diff: '   ' });
+
+    assert.equal(res.changesRequested, false);
+    assert.equal(res.reviewLog, '');
+    assert.equal(calls.length, 0, 'no turns run on an empty diff');
+  });
+
+  it('honors the reviewer model override on the review turn', async () => {
+    const { fake, calls } = makeFake('VERDICT: LGTM');
+
+    await runReview(fake, { model: 'claude-opus-4-8' });
+
+    assert.equal(calls[0].options.model, 'claude-opus-4-8');
+  });
+
+  it('defaults the review turn to the configured model (no override)', async () => {
+    const { fake, calls } = makeFake('VERDICT: LGTM');
+
+    await runReview(fake);
+
+    assert.equal(calls[0].options.model, undefined);
+  });
+});

--- a/src/services/self-review-executor.ts
+++ b/src/services/self-review-executor.ts
@@ -1,0 +1,170 @@
+import chalk from 'chalk';
+import type { IClaudeExecutor } from './executor-factory.js';
+import type { SelfReviewConfig } from '../config.js';
+import { queryLearnings } from '../learnings/index.js';
+import type { LearningsQueryResult } from '../learnings/types.js';
+
+/**
+ * The reviewer persona for the pre-PR self review. A separate Claude Code
+ * session reviews the change before it becomes a pull request — the same
+ * "Claude Code reviewing its own code" pass a careful engineer would do before
+ * hitting "Create PR". It is grounded in the team's institutional learnings and
+ * an explicit engineering-quality bar, and it only asks for changes that are
+ * genuinely worth making.
+ */
+const SELF_REVIEW_SYSTEM_PROMPT = `You are a meticulous principal engineer performing a pre-merge code review of a teammate's change before they open a pull request. Review the change (the diff) grounded in how the surrounding codebase actually works — read the relevant files to check your assumptions.
+
+Hold the change to these standards:
+- Correctness: bugs, logic errors, unhandled edge cases, wrong assumptions, race conditions, off-by-ones.
+- Security: input validation, injection, authz/authn, secrets in code, unsafe deserialization, path traversal.
+- Follow existing patterns: match the conventions, abstractions, and idioms already in this codebase instead of introducing new ones for no reason.
+- Reuse over reinvention: use existing helpers, components, and utilities; extract shared logic rather than duplicating it; don't reinvent what the repo or a well-established library already provides.
+- Right-sized, not over-engineered: no speculative abstraction, configuration, or generality for needs that don't exist yet — the simplest solution that fully solves the problem.
+- Maintainability, no tech debt: clear names, no dead or commented-out code, no needless complexity, errors handled rather than swallowed, nothing a future reader will curse.
+- Tests & docs: coverage proportional to the risk; update docs, comments, and types when behavior changes.
+
+Be specific and concrete: reference file paths and line numbers, and prefer the smallest change that fixes the real issue. Do not manufacture problems — if the change is sound, say so. You may read and inspect the codebase, but do not modify it in this turn.
+
+When you finish, end your message with exactly one line, nothing after it — one of:
+VERDICT: LGTM              (no changes needed; the change is ready to ship)
+VERDICT: CHANGES_REQUESTED (there are concrete, worth-fixing issues to address before opening the PR)`;
+
+const MAX_DIFF_CHARS = 60000;
+
+export interface SelfReviewParams {
+  /** The diff to review (working-tree or branch diff, depending on the caller). */
+  diff: string;
+  /** The worktree path where the reviewer inspects and the fixer edits. */
+  executionPath: string;
+  /** Main repo path (where `.ivan/` lives) for querying learnings. */
+  learningsRepoPath: string;
+  /**
+   * The implementer's session, resumed for the fix turn so it applies changes
+   * with the full context of the work it just did.
+   */
+  implementerSessionId?: string;
+}
+
+export interface SelfReviewResult {
+  /** True when the reviewer asked for changes and a fix turn was run. */
+  changesRequested: boolean;
+  /** The reviewer's full output, for the execution log. */
+  reviewLog: string;
+}
+
+/**
+ * Runs a pre-PR "Claude Code reviews its own code" pass: a fresh reviewer
+ * session critiques the change against the team's learnings and engineering
+ * best practices, and — when it requests changes — the implementer session
+ * silently applies the fixes before the PR is opened. Correctness of the fixes
+ * is the caller's to commit; this class just leaves them in the worktree.
+ */
+export class SelfReviewExecutor {
+  constructor(
+    private executor: IClaudeExecutor,
+    private config: SelfReviewConfig
+  ) {}
+
+  async run(params: SelfReviewParams): Promise<SelfReviewResult> {
+    const { diff, executionPath, learningsRepoPath, implementerSessionId } =
+      params;
+
+    if (!diff.trim()) {
+      return { changesRequested: false, reviewLog: '' };
+    }
+
+    const brief = await this.buildBrief(learningsRepoPath, diff);
+
+    this.header('🤖 Self-review: Claude Code reviewing its own changes');
+    const review = await this.executor.executeTurn(
+      this.reviewPrompt(this.truncateDiff(diff), brief),
+      executionPath,
+      {
+        permissionMode: 'plan',
+        readOnly: true,
+        systemPrompt: SELF_REVIEW_SYSTEM_PROMPT,
+        ...(this.config.model ? { model: this.config.model } : {})
+      }
+    );
+    const reviewText = review.log?.trim() || review.lastMessage;
+
+    if (!this.changesRequested(reviewText)) {
+      console.log(chalk.green('✅ Self-review: no changes requested.'));
+      return { changesRequested: false, reviewLog: reviewText };
+    }
+
+    this.header('🔧 Self-review: applying review fixes');
+    await this.executor.executeTurn(this.fixPrompt(reviewText), executionPath, {
+      sessionId: implementerSessionId,
+      permissionMode: 'bypassPermissions'
+    });
+
+    return { changesRequested: true, reviewLog: reviewText };
+  }
+
+  /**
+   * A missing/malformed verdict is treated as LGTM: the self-review is an
+   * additive safety net, so an unparseable review must never trigger an
+   * unbounded fix turn. Only an explicit CHANGES_REQUESTED requests fixes.
+   */
+  private changesRequested(message: string): boolean {
+    return /VERDICT:\s*CHANGES_REQUESTED/i.test(message);
+  }
+
+  private async buildBrief(
+    learningsRepoPath: string,
+    queryText: string
+  ): Promise<string> {
+    let learnings: LearningsQueryResult[] = [];
+    try {
+      learnings = await queryLearnings(learningsRepoPath, queryText, {
+        limit: 8
+      });
+    } catch {
+      // No learnings store, or it failed to open — self-review still works.
+      return '';
+    }
+    if (learnings.length === 0) return '';
+
+    return learnings
+      .map((l) => {
+        const label = l.title || l.kind;
+        const parts = [`- [${label}] ${l.statement}`];
+        if (l.rationale) parts.push(`  Why: ${l.rationale}`);
+        if (l.applicability) parts.push(`  When: ${l.applicability}`);
+        return parts.join('\n');
+      })
+      .join('\n');
+  }
+
+  private reviewPrompt(diff: string, brief: string): string {
+    const briefBlock = brief
+      ? `\nInstitutional knowledge from this team (lessons from past PRs and coding sessions — weigh these heavily):\n${brief}\n`
+      : '';
+    return `Review the change below before it becomes a pull request. Inspect the codebase read-only to ground your review in how the code actually behaves.
+${briefBlock}
+DIFF:
+${diff}`;
+  }
+
+  private fixPrompt(reviewNotes: string): string {
+    return `A code reviewer reviewed your changes before opening the PR and asked for the following fixes:
+
+${reviewNotes}
+
+Apply the fixes for the real, in-scope issues now. Follow the existing patterns and the team's conventions, reuse existing code rather than duplicating it, and keep the changes minimal — do not broaden scope or over-engineer. If any requested item is genuinely not worth doing or is out of scope, briefly note why instead of forcing it.`;
+  }
+
+  private truncateDiff(diff: string): string {
+    if (diff.length <= MAX_DIFF_CHARS) return diff;
+    return (
+      diff.slice(0, MAX_DIFF_CHARS) +
+      `\n\n[... diff truncated at ${MAX_DIFF_CHARS} characters. Read the files directly to review the rest. ...]`
+    );
+  }
+
+  private header(text: string): void {
+    console.log('');
+    console.log(chalk.magenta.bold(text));
+  }
+}

--- a/src/services/task-executor.ts
+++ b/src/services/task-executor.ts
@@ -20,6 +20,7 @@ import {
 } from './service-factory.js';
 import { PromptRewriter } from './prompt-rewriter.js';
 import { CollaborativeExecutor } from './collaborative-executor.js';
+import { SelfReviewExecutor } from './self-review-executor.js';
 import type { ExecutionMode } from '../types/non-interactive-config.js';
 import type { TurnResult } from './executor-factory.js';
 import type { CollaborativeRunResult } from './collaborative-executor.js';
@@ -35,6 +36,9 @@ export class TaskExecutor {
   private repoInstructions: string | undefined;
   private baseBranch: string | undefined;
   private executionMode: ExecutionMode;
+  // Whether Ivan runs a Claude Code self code review (and applies fixes) before
+  // opening a PR. Resolved from config + the --no-self-review flag per run.
+  private selfReviewEnabled: boolean = true;
 
   constructor() {
     this.jobManager = new JobManager();
@@ -44,6 +48,60 @@ export class TaskExecutor {
     this.repoInstructions = undefined;
     this.baseBranch = undefined;
     this.executionMode = 'simple';
+  }
+
+  /**
+   * Resolves whether the pre-PR self review runs this session. A per-run
+   * override (the --no-self-review flag or a non-interactive `selfReview: false`)
+   * can only turn it OFF; otherwise the global config decides (default on).
+   */
+  private resolveSelfReview(perRunOverride?: boolean): boolean {
+    if (perRunOverride === false) return false;
+    return this.configManager.getSelfReviewConfig().enabled;
+  }
+
+  /**
+   * Runs the pre-PR self review: Claude Code reviews the given diff against the
+   * team's learnings and engineering best practices and silently applies fixes.
+   * Fixes are left in the worktree for the caller to commit. No-op when disabled
+   * or when there is nothing to review.
+   */
+  private async runSelfReview(
+    executionPath: string,
+    diff: string,
+    implementerSessionId?: string
+  ): Promise<void> {
+    if (!this.selfReviewEnabled || !diff.trim()) return;
+    const reviewer = new SelfReviewExecutor(
+      this.getClaudeExecutor(),
+      this.configManager.getSelfReviewConfig()
+    );
+    await reviewer.run({
+      diff,
+      executionPath,
+      learningsRepoPath: this.workingDir,
+      implementerSessionId
+    });
+  }
+
+  /**
+   * Commits everything in the worktree with retry, mirroring the per-task commit
+   * loop's tolerance of pre-commit hooks that reformat and abort the first
+   * attempt. Used for the extra commit that self-review fixes produce in the
+   * single-PR flow. Returns false if every attempt failed.
+   */
+  private async commitWithRetry(message: string): Promise<boolean> {
+    if (!this.gitManager) throw new Error('GitManager not initialized');
+    const maxAttempts = 3;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        await this.gitManager.commitChanges(message);
+        return true;
+      } catch {
+        // Pre-commit hook may have reformatted files; retry re-stages them.
+      }
+    }
+    return false;
   }
 
   /**
@@ -122,11 +180,13 @@ export class TaskExecutor {
   async executeWorkflow(
     rewritePrompt: boolean = false,
     baseBranch?: string,
-    mode: ExecutionMode = 'simple'
+    mode: ExecutionMode = 'simple',
+    selfReview?: boolean
   ): Promise<void> {
     try {
       this.baseBranch = baseBranch?.trim() || undefined;
       this.executionMode = mode;
+      this.selfReviewEnabled = this.resolveSelfReview(selfReview);
 
       if (mode === 'expert') {
         console.log(
@@ -519,6 +579,13 @@ export class TaskExecutor {
       if (!this.gitManager) {
         throw new Error('GitManager not initialized');
       }
+      // Ask Claude Code to review its own change and apply fixes before the PR.
+      // Runs before the commit so fixes fold into the same commit.
+      await this.runSelfReview(
+        executionPath,
+        this.gitManager.getDiff(),
+        result.sessionId
+      );
       const changedFiles = this.gitManager.getChangedFiles();
       if (changedFiles.length === 0) {
         if (!quiet)
@@ -987,6 +1054,28 @@ export class TaskExecutor {
           );
       }
 
+      // Self-review the whole change once (all tasks are already committed), and
+      // commit any fixes as a follow-up commit before pushing.
+      if (this.selfReviewEnabled) {
+        const executionPath = worktreePath || this.workingDir;
+        const branchDiff = this.gitManager.getDiff(
+          `origin/${targetBranch}`,
+          'HEAD'
+        );
+        await this.runSelfReview(executionPath, branchDiff, sessionId);
+        const fixFiles = this.gitManager.getChangedFiles();
+        if (fixFiles.length > 0) {
+          if (!quiet) spinner = ora('Committing self-review fixes...').start();
+          const committed = await this.commitWithRetry(
+            'chore: apply self-review fixes'
+          );
+          if (spinner) {
+            if (committed) spinner.succeed('Self-review fixes committed');
+            else spinner.warn('Could not commit self-review fixes');
+          }
+        }
+      }
+
       // After all tasks are complete, create a single PR
       if (!quiet) spinner = ora('Pushing branch...').start();
       if (!this.gitManager) {
@@ -1065,6 +1154,7 @@ export class TaskExecutor {
     try {
       this.baseBranch = config.baseBranch?.trim() || undefined;
       this.executionMode = config.mode || 'simple';
+      this.selfReviewEnabled = this.resolveSelfReview(config.selfReview);
 
       // Quiet mode: suppress all intermediate output
       const executor = this.getClaudeExecutor();

--- a/src/types/non-interactive-config.ts
+++ b/src/types/non-interactive-config.ts
@@ -50,4 +50,12 @@ export interface NonInteractiveConfig {
    * - 'expert': collaborative architect↔implementer loop informed by learnings
    */
   mode?: ExecutionMode;
+
+  /**
+   * Whether Ivan runs a Claude Code self code review (and applies fixes) before
+   * opening the PR. Defaults to true; set false to skip it (mirrors
+   * --no-self-review). The global `selfReview.enabled` config is the other
+   * opt-out.
+   */
+  selfReview?: boolean;
 }


### PR DESCRIPTION
## What

Before Ivan opens a pull request, it now does what a careful engineer does last: **asks Claude Code to review its own diff — and quietly fixes what it finds.** Runs in **every mode** (simple, expert, loop), so even a one-shot `simple` run gets a review pass before it reaches you.

```
implement ─▶ 🤖 self-review + fix ─▶ commit ─▶ PR
```

## How it works

- A **fresh, read-only reviewer session** critiques the change (`plan` mode, can't edit), then the **implementer session** applies the fixes (`bypassPermissions`).
- **Single-task flow:** review runs *before* the commit, so fixes fold into the same commit.
- **Single-PR (multi-task) flow:** review runs after all task commits; fixes land as a follow-up `chore: apply self-review fixes` commit before push.
- Conservative: only edits when the reviewer returns `VERDICT: CHANGES_REQUESTED`; an unclear/verdict-less review is treated as ship-it (never an unbounded fix).

## Grounded in learnings + best practices

The reviewer is fed:
- 🧠 **Institutional learnings** — the same `queryLearnings` store expert mode uses, injected into the review.
- 📐 **An explicit engineering bar** — correctness & edge cases, security, *follow existing codebase patterns*, *reuse/extract instead of reinventing*, *don't over-engineer*, and maintainability without tech debt.

## Config / opt-out (on by default)

```bash
ivan "Fix the timezone bug" --no-self-review   # skip for this run
```
```jsonc
// ~/.ivan/config.json
{ "selfReview": { "enabled": true, "model": "claude-opus-4-8" } }
```
- `--no-self-review` (and non-interactive `selfReview: false`) can only turn it **off**; global `selfReview.enabled: false` is the other opt-out.
- `selfReview.model` optionally runs the reviewer on a stronger model (defaults to the implementer model).

## Tests

6 fully-offline unit tests via `npm run test:unit` (`node:test` + tsx) driving `SelfReviewExecutor` through a fake executor — no Claude/git/network:
- fix turn runs on `CHANGES_REQUESTED` (resumes implementer session, `bypassPermissions`);
- no-op on `LGTM` and on a missing/malformed verdict;
- empty-diff skip;
- reviewer model override vs. default.

`typecheck` / `lint` / `prettier` / `build` all clean.

## Notes

- **New `SelfReviewExecutor`** uses the same constructor-injection seam as `CollaborativeExecutor` for offline testability, and mirrors its learnings-brief helper (kept self-contained to avoid touching `collaborative-executor.ts`, which is evolving on another branch).
- `commitWithRetry` mirrors the existing per-task commit's tolerance of reformatting pre-commit hooks; if fixes can't be committed after retries, Ivan warns and proceeds rather than failing the run.
- Composes cleanly with expert/loop review rounds — this is an additional, Claude-Code-native gate on top of them.

Files: `self-review-executor.ts` (+tests), `task-executor.ts` (both flows + flag threading + commit handling), `config.ts` (`selfReview` config), `index.ts` (`--no-self-review`), `non-interactive-config.ts`, README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)