### PR TITLE
Add --self-review flag: Claude self-review before opening a PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ ivan                          # interactive: Ivan asks what to build
 ivan "task description"       # headless: run a task directly
 ivan --mode expert "task"     # collaborative architect ↔ implementer loop
 ivan --base-branch dev "task" # branch work off a specific local base branch
+ivan --self-review "task"     # Claude self-reviews the branch before opening the PR
 ivan -c config.json           # run from a JSON config (CI-friendly)
 ivan -c '{"tasks":["A","B"],"mode":"expert"}'   # inline JSON config
 ivan address [PR#]            # address PR review comments or failing checks

--- a/example-config.json
+++ b/example-config.json
@@ -4,5 +4,6 @@
   ],
   "generateSubtasks": false,
   "prStrategy": "multiple",
-  "waitForComments": true
+  "waitForComments": true,
+  "selfReview": false
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -840,20 +840,14 @@ async function main() {
       rewritePrompt: hasRewriteFlag,
       baseBranch,
       mode: modeFlag,
-<<<<<<< Updated upstream
-      selfReview: hasSelfReviewFlag
-=======
+      selfReview: hasSelfReviewFlag,
       spec: specFiles
->>>>>>> Stashed changes
     } = program.opts<{
       rewritePrompt: boolean;
       baseBranch?: string;
       mode?: string;
-<<<<<<< Updated upstream
       selfReview?: boolean;
-=======
       spec?: string[];
->>>>>>> Stashed changes
     }>();
     const mode = resolveMode(modeFlag);
     const specTasks =
@@ -956,11 +950,8 @@ async function main() {
         hasRewriteFlag,
         baseBranch,
         mode,
-<<<<<<< Updated upstream
-        hasSelfReviewFlag
-=======
+        hasSelfReviewFlag,
         specTasks
->>>>>>> Stashed changes
       );
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,10 @@ program
   .option(
     '--mode <mode>',
     'Execution mode: "simple" (one-shot hand-off, default) or "expert" (collaborative architect↔implementer loop informed by learnings)'
+  )
+  .option(
+    '--spec <files...>',
+    'Read task descriptions from one or more files (one task per line, # comments and blank lines ignored) instead of prompting via the editor'
   );
 
 registerLearningsCommands(program);
@@ -801,6 +805,21 @@ async function runNonInteractive(configInput: string): Promise<void> {
   }
 }
 
+function readTasksFromSpecFiles(specFiles: string[]): string[] {
+  const tasks: string[] = [];
+  for (const file of specFiles) {
+    if (!existsSync(file)) {
+      throw new Error(`--spec file not found: ${file}`);
+    }
+    const content = readFileSync(file, 'utf-8').trim();
+    if (content.length === 0) {
+      throw new Error(`--spec file is empty: ${file}`);
+    }
+    tasks.push(content);
+  }
+  return tasks;
+}
+
 function resolveMode(raw: string | undefined): ExecutionMode {
   const value = (raw || 'simple').toLowerCase();
   if (value !== 'simple' && value !== 'expert') {
@@ -821,14 +840,26 @@ async function main() {
       rewritePrompt: hasRewriteFlag,
       baseBranch,
       mode: modeFlag,
+<<<<<<< Updated upstream
       selfReview: hasSelfReviewFlag
+=======
+      spec: specFiles
+>>>>>>> Stashed changes
     } = program.opts<{
       rewritePrompt: boolean;
       baseBranch?: string;
       mode?: string;
+<<<<<<< Updated upstream
       selfReview?: boolean;
+=======
+      spec?: string[];
+>>>>>>> Stashed changes
     }>();
     const mode = resolveMode(modeFlag);
+    const specTasks =
+      specFiles && specFiles.length > 0
+        ? readTasksFromSpecFiles(specFiles)
+        : undefined;
 
     // Check for -c/--config flag
     const configFlagIndex = args.findIndex(
@@ -925,7 +956,11 @@ async function main() {
         hasRewriteFlag,
         baseBranch,
         mode,
+<<<<<<< Updated upstream
         hasSelfReviewFlag
+=======
+        specTasks
+>>>>>>> Stashed changes
       );
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -921,7 +921,12 @@ async function main() {
       await runMigrations();
 
       const taskExecutor = new TaskExecutor();
-      await taskExecutor.executeWorkflow(hasRewriteFlag, baseBranch, mode);
+      await taskExecutor.executeWorkflow(
+        hasRewriteFlag,
+        baseBranch,
+        mode,
+        hasSelfReviewFlag
+      );
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,10 @@ program
     'Rewrite verbose task descriptions before execution using GPT-4o-mini'
   )
   .option(
+    '--self-review',
+    'Have Claude self-review the changes before opening a PR'
+  )
+  .option(
     '--mode <mode>',
     'Execution mode: "simple" (one-shot hand-off, default) or "expert" (collaborative architect↔implementer loop informed by learnings)'
   );
@@ -738,13 +742,15 @@ async function runNonInteractive(configInput: string): Promise<void> {
     }
 
     // Apply --rewrite-prompt flag if passed on CLI
-    const { rewritePrompt, baseBranch, mode } = program.opts<{
+    const { rewritePrompt, baseBranch, mode, selfReview } = program.opts<{
       rewritePrompt: boolean;
       baseBranch?: string;
       mode?: string;
+      selfReview?: boolean;
     }>();
     if (rewritePrompt) config.rewritePrompt = true;
     if (baseBranch) config.baseBranch = baseBranch;
+    if (selfReview) config.selfReview = true;
     // CLI --mode overrides the config file; config value wins only if no flag.
     if (mode !== undefined) config.mode = resolveMode(mode);
 
@@ -814,11 +820,13 @@ async function main() {
     const {
       rewritePrompt: hasRewriteFlag,
       baseBranch,
-      mode: modeFlag
+      mode: modeFlag,
+      selfReview: hasSelfReviewFlag
     } = program.opts<{
       rewritePrompt: boolean;
       baseBranch?: string;
       mode?: string;
+      selfReview?: boolean;
     }>();
     const mode = resolveMode(modeFlag);
 
@@ -864,7 +872,8 @@ async function main() {
         tasks: [taskDescription],
         rewritePrompt: hasRewriteFlag,
         mode,
-        ...(baseBranch && { baseBranch })
+        ...(baseBranch && { baseBranch }),
+        ...(hasSelfReviewFlag && { selfReview: true })
       };
 
       // Check configuration before running

--- a/src/learnings/import-learnings-command.ts
+++ b/src/learnings/import-learnings-command.ts
@@ -232,7 +232,5 @@ function parseCsvTimestamp(value: string | undefined): string | undefined {
   }
 
   const fallback = new Date(value);
-  return Number.isNaN(fallback.getTime())
-    ? undefined
-    : fallback.toISOString();
+  return Number.isNaN(fallback.getTime()) ? undefined : fallback.toISOString();
 }

--- a/src/services/job-manager.ts
+++ b/src/services/job-manager.ts
@@ -19,38 +19,59 @@ export class JobManager {
 
   async promptForTasks(
     workingDir: string,
-    repositoryId: number
+    repositoryId: number,
+    prefilledTasks?: string[]
   ): Promise<{ job: Job; tasks: Task[]; prStrategy: 'multiple' | 'single' }> {
-    console.log(chalk.blue.bold('🎯 What would you like to work on today?'));
-    console.log('');
+    let inputTasks: string[];
 
-    const { taskInput } = await inquirer.prompt([
-      {
-        type: 'editor',
-        name: 'taskInput',
-        message: 'Enter task(s) - one per line (press Enter to open editor):',
-        default:
-          '# Enter your tasks below (one per line)\n# Lines starting with # will be ignored\n\n',
-        validate: (input: string) => {
-          const cleanedInput = input
-            .split('\n')
-            .filter((line) => line.trim() && !line.trim().startsWith('#'))
-            .join('\n')
-            .trim();
+    if (prefilledTasks && prefilledTasks.length > 0) {
+      inputTasks = prefilledTasks;
+      console.log(
+        chalk.blue.bold(
+          `🎯 Loaded ${inputTasks.length} task(s) from --spec:`
+        )
+      );
+      inputTasks.forEach((task, index) => {
+        const firstLine = task.split('\n')[0].trim();
+        const preview =
+          firstLine.length > 100 ? `${firstLine.slice(0, 100)}…` : firstLine;
+        const lineCount = task.split('\n').length;
+        const suffix = lineCount > 1 ? chalk.gray(` (${lineCount} lines)`) : '';
+        console.log(chalk.gray(`  ${index + 1}. ${preview}`) + suffix);
+      });
+      console.log('');
+    } else {
+      console.log(chalk.blue.bold('🎯 What would you like to work on today?'));
+      console.log('');
 
-          if (!cleanedInput || cleanedInput.length === 0) {
-            return 'Please enter at least one task';
+      const { taskInput } = await inquirer.prompt([
+        {
+          type: 'editor',
+          name: 'taskInput',
+          message: 'Enter task(s) - one per line (press Enter to open editor):',
+          default:
+            '# Enter your tasks below (one per line)\n# Lines starting with # will be ignored\n\n',
+          validate: (input: string) => {
+            const cleanedInput = input
+              .split('\n')
+              .filter((line) => line.trim() && !line.trim().startsWith('#'))
+              .join('\n')
+              .trim();
+
+            if (!cleanedInput || cleanedInput.length === 0) {
+              return 'Please enter at least one task';
+            }
+            return true;
           }
-          return true;
         }
-      }
-    ]);
+      ]);
 
-    // Parse newline-separated tasks, filtering out empty lines and comments
-    const inputTasks = taskInput
-      .split('\n')
-      .map((task: string) => task.trim())
-      .filter((task: string) => task.length > 0 && !task.startsWith('#'));
+      // Parse newline-separated tasks, filtering out empty lines and comments
+      inputTasks = taskInput
+        .split('\n')
+        .map((task: string) => task.trim())
+        .filter((task: string) => task.length > 0 && !task.startsWith('#'));
+    }
 
     let finalTasks = inputTasks;
     let prStrategy: 'multiple' | 'single' = 'multiple';

--- a/src/services/job-manager.ts
+++ b/src/services/job-manager.ts
@@ -27,9 +27,7 @@ export class JobManager {
     if (prefilledTasks && prefilledTasks.length > 0) {
       inputTasks = prefilledTasks;
       console.log(
-        chalk.blue.bold(
-          `🎯 Loaded ${inputTasks.length} task(s) from --spec:`
-        )
+        chalk.blue.bold(`🎯 Loaded ${inputTasks.length} task(s) from --spec:`)
       );
       inputTasks.forEach((task, index) => {
         const firstLine = task.split('\n')[0].trim();

--- a/src/services/task-executor.ts
+++ b/src/services/task-executor.ts
@@ -732,8 +732,16 @@ export class TaskExecutor {
       if (!this.gitManager) {
         throw new Error('GitManager not initialized');
       }
+      // Uncommitted working-tree changes still waiting to be committed.
       const changedFiles = this.gitManager.getChangedFiles();
-      if (changedFiles.length === 0) {
+      // Total diff vs. the base branch: covers changes Claude already
+      // committed itself during execution (e.g. mid-task or via self-review),
+      // which leave a clean working tree but still need to be pushed/PR'd.
+      const changedFilesFromBase =
+        changedFiles.length === 0
+          ? this.gitManager.getChangedFiles(targetBranch)
+          : changedFiles;
+      if (changedFilesFromBase.length === 0) {
         if (!quiet)
           console.log(
             chalk.yellow(
@@ -744,26 +752,37 @@ export class TaskExecutor {
         return;
       }
 
-      if (!this.gitManager) {
-        throw new Error('GitManager not initialized');
+      let sessionId: string | undefined = result.sessionId;
+      if (changedFiles.length === 0) {
+        if (!quiet)
+          console.log(
+            chalk.blue(
+              'ℹ️  Changes were already committed during task execution'
+            )
+          );
+      } else {
+        if (!this.gitManager) {
+          throw new Error('GitManager not initialized');
+        }
+        const diff = this.gitManager.getDiff();
+
+        if (!quiet) spinner = ora('Generating commit message...').start();
+        const commitMessage =
+          await this.getOpenAIService().generateCommitMessage(
+            diff,
+            changedFiles
+          );
+        if (spinner)
+          spinner.succeed(`Commit message generated: ${commitMessage}`);
+
+        sessionId = await this.commitWithFixLoop(
+          commitMessage,
+          executionPath,
+          task.uuid,
+          quiet,
+          result.sessionId
+        );
       }
-      const diff = this.gitManager.getDiff();
-
-      if (!quiet) spinner = ora('Generating commit message...').start();
-      const commitMessage = await this.getOpenAIService().generateCommitMessage(
-        diff,
-        changedFiles
-      );
-      if (spinner)
-        spinner.succeed(`Commit message generated: ${commitMessage}`);
-
-      const sessionId = await this.commitWithFixLoop(
-        commitMessage,
-        executionPath,
-        task.uuid,
-        quiet,
-        result.sessionId
-      );
 
       // Optionally self-review the branch before opening the PR
       if (this.selfReviewEnabled) {

--- a/src/services/task-executor.ts
+++ b/src/services/task-executor.ts
@@ -800,7 +800,10 @@ export class TaskExecutor {
 
       // Recompute the diff/changed files against the base branch so the PR
       // description reflects any commits self-review made after the initial commit.
-      const finalDiff = this.gitManager.getDiff(`origin/${targetBranch}`, 'HEAD');
+      const finalDiff = this.gitManager.getDiff(
+        `origin/${targetBranch}`,
+        'HEAD'
+      );
       const finalChangedFiles = this.gitManager.getChangedFiles(
         `origin/${targetBranch}`
       );

--- a/src/services/task-executor.ts
+++ b/src/services/task-executor.ts
@@ -325,7 +325,11 @@ export class TaskExecutor {
     rewritePrompt: boolean = false,
     baseBranch?: string,
     mode: ExecutionMode = 'simple',
+<<<<<<< Updated upstream
     selfReview: boolean = false
+=======
+    prefilledTasks?: string[]
+>>>>>>> Stashed changes
   ): Promise<void> {
     try {
       this.baseBranch = baseBranch?.trim() || undefined;
@@ -434,7 +438,8 @@ export class TaskExecutor {
 
       const { tasks, prStrategy } = await this.jobManager.promptForTasks(
         this.workingDir,
-        repository.id
+        repository.id,
+        prefilledTasks
       );
 
       console.log('');

--- a/src/services/task-executor.ts
+++ b/src/services/task-executor.ts
@@ -24,6 +24,9 @@ import type { ExecutionMode } from '../types/non-interactive-config.js';
 import type { TurnResult } from './executor-factory.js';
 import type { CollaborativeRunResult } from './collaborative-executor.js';
 
+const SELF_REVIEW_PROMPT =
+  "ok review the changes in the current branch carefully. make sure it follows repo convention, reusable component/utils/etc. don't over-engineer, dont reinvent.";
+
 export class TaskExecutor {
   private jobManager: JobManager;
   private gitManager: IGitManager | null = null;
@@ -35,6 +38,7 @@ export class TaskExecutor {
   private repoInstructions: string | undefined;
   private baseBranch: string | undefined;
   private executionMode: ExecutionMode;
+  private selfReviewEnabled: boolean;
 
   constructor() {
     this.jobManager = new JobManager();
@@ -44,6 +48,7 @@ export class TaskExecutor {
     this.repoInstructions = undefined;
     this.baseBranch = undefined;
     this.executionMode = 'simple';
+    this.selfReviewEnabled = false;
   }
 
   /**
@@ -117,6 +122,203 @@ export class TaskExecutor {
       this.openaiService = new OpenAIService();
     }
     return this.openaiService;
+  }
+
+  /**
+   * Commits staged changes, retrying up to three times by handing pre-commit
+   * hook failures back to Claude to fix. Returns the (possibly updated) Claude
+   * session ID so callers can keep threading conversational context.
+   */
+  private async commitWithFixLoop(
+    commitMessage: string,
+    executionPath: string,
+    taskUuid: string,
+    quiet: boolean,
+    sessionId?: string
+  ): Promise<string | undefined> {
+    let spinner = quiet ? null : ora('Committing changes...').start();
+
+    let commitAttempts = 0;
+    const maxCommitAttempts = 3;
+    let commitSucceeded = false;
+
+    while (commitAttempts < maxCommitAttempts && !commitSucceeded) {
+      try {
+        if (!this.gitManager) {
+          throw new Error('GitManager not initialized');
+        }
+        await this.gitManager.commitChanges(commitMessage);
+        // Only show success message if spinner is running (first attempt)
+        if (spinner) {
+          if (commitAttempts === 0) {
+            spinner.succeed('Changes committed');
+          } else if (spinner.isSpinning) {
+            spinner.succeed('Commit successful after retry');
+          }
+        }
+        commitSucceeded = true;
+      } catch (commitError) {
+        commitAttempts++;
+
+        const errorMessage =
+          commitError instanceof Error
+            ? commitError.message
+            : String(commitError);
+
+        // Check if this is a pre-commit hook failure
+        if (
+          errorMessage.includes('pre-commit') &&
+          commitAttempts < maxCommitAttempts
+        ) {
+          if (spinner) {
+            spinner.fail(
+              `Pre-commit hook failed (attempt ${commitAttempts}/${maxCommitAttempts})`
+            );
+            console.log(
+              chalk.yellow('🔧 Running Claude to fix pre-commit errors...')
+            );
+          }
+
+          // Extract the error details from the commit error
+          let errorDetails = errorMessage;
+
+          // Condense error details if they're too large (over 10,000 characters)
+          const MAX_ERROR_LENGTH = 10000;
+          if (errorDetails.length > MAX_ERROR_LENGTH) {
+            if (!quiet) {
+              console.log(
+                chalk.yellow(
+                  `📊 Build output is large (${errorDetails.length} chars), condensing with AI...`
+                )
+              );
+            }
+            try {
+              errorDetails = await this.getOpenAIService().condenseBuildOutput(
+                errorDetails,
+                MAX_ERROR_LENGTH
+              );
+            } catch (condenseError) {
+              // If condensation fails, just use truncation
+              console.warn(
+                chalk.yellow(
+                  'Failed to condense output, using truncation instead'
+                ),
+                condenseError
+              );
+            }
+          }
+
+          // Prepare prompt for Claude to fix the errors
+          const fixPrompt = `Fix the following pre-commit hook errors:\n\n${errorDetails}\n\nPlease fix all TypeScript errors, linting issues, and any other problems preventing the commit.`;
+
+          if (!quiet)
+            spinner = ora('Running Claude to fix pre-commit errors...').start();
+
+          try {
+            // Run Claude to fix the errors (pass session ID to maintain context)
+            const fixResult = await this.getClaudeExecutor().executeTask(
+              fixPrompt,
+              executionPath,
+              sessionId
+            );
+            // Update session ID
+            sessionId = fixResult.sessionId;
+            if (spinner) spinner.succeed('Claude attempted to fix the errors');
+
+            // Update the execution log with the fix attempt
+            const previousLog =
+              await this.jobManager.getTaskExecutionLog(taskUuid);
+            await this.jobManager.updateTaskExecutionLog(
+              taskUuid,
+              `${previousLog}\n\n--- Pre-commit Fix Attempt ${commitAttempts} ---\n${fixResult.log}`
+            );
+
+            // Try to commit again on the next iteration
+            if (!quiet) spinner = ora('Retrying commit...').start();
+          } catch (fixError) {
+            if (spinner) spinner.fail('Failed to run Claude to fix errors');
+            if (!quiet)
+              console.error(chalk.red('Claude fix attempt failed:'), fixError);
+            throw commitError; // Re-throw the original error
+          }
+        } else {
+          // Not a pre-commit error or max attempts reached
+          throw commitError;
+        }
+      }
+    }
+
+    if (!commitSucceeded) {
+      throw new Error(
+        `Failed to commit after ${maxCommitAttempts} attempts due to pre-commit hook failures`
+      );
+    }
+
+    return sessionId;
+  }
+
+  /**
+   * Runs a Claude self-review pass over the branch's changes before a PR is
+   * opened. Any fixes the review produces are committed through the same
+   * pre-commit fix loop as the original implementation.
+   */
+  private async runSelfReview(
+    executionPath: string,
+    taskUuid: string,
+    quiet: boolean,
+    sessionId?: string
+  ): Promise<string | undefined> {
+    let spinner = quiet
+      ? null
+      : ora('Running self-review with Claude Code...').start();
+
+    const reviewResult = await this.getClaudeExecutor().executeTask(
+      SELF_REVIEW_PROMPT,
+      executionPath,
+      sessionId
+    );
+    sessionId = reviewResult.sessionId;
+    if (spinner) spinner.succeed('Self-review completed');
+
+    const previousLog = await this.jobManager.getTaskExecutionLog(taskUuid);
+    await this.jobManager.updateTaskExecutionLog(
+      taskUuid,
+      `${previousLog}\n\n--- Self-Review ---\n${reviewResult.log}`
+    );
+
+    if (!this.gitManager) {
+      throw new Error('GitManager not initialized');
+    }
+    const changedFiles = this.gitManager.getChangedFiles();
+    if (changedFiles.length === 0) {
+      if (!quiet)
+        console.log(chalk.green('✨ Self-review made no additional changes'));
+      return sessionId;
+    }
+
+    if (!quiet)
+      console.log(
+        chalk.blue(
+          `🔧 Self-review made changes to ${changedFiles.length} file(s)`
+        )
+      );
+
+    const diff = this.gitManager.getDiff();
+
+    if (!quiet) spinner = ora('Generating commit message...').start();
+    const commitMessage = await this.getOpenAIService().generateCommitMessage(
+      diff,
+      changedFiles
+    );
+    if (spinner) spinner.succeed(`Commit message generated: ${commitMessage}`);
+
+    return this.commitWithFixLoop(
+      commitMessage,
+      executionPath,
+      taskUuid,
+      quiet,
+      sessionId
+    );
   }
 
   async executeWorkflow(
@@ -252,16 +454,24 @@ export class TaskExecutor {
         let shouldWaitForComments = false;
         const inquirer = (await import('inquirer')).default;
 
-        const { waitForComments } = await inquirer.prompt([
+        const { waitForComments, selfReview } = await inquirer.prompt([
           {
             type: 'confirm',
             name: 'waitForComments',
             message:
               'After completing tasks, would you like to wait 30 minutes for PR reviews and automatically address any comments?',
             default: false
+          },
+          {
+            type: 'confirm',
+            name: 'selfReview',
+            message:
+              'Would you like Claude to self-review its changes before opening each PR?',
+            default: false
           }
         ]);
         shouldWaitForComments = waitForComments;
+        this.selfReviewEnabled = selfReview;
 
         // Optionally rewrite prompts before execution
         if (rewritePrompt) {
@@ -544,128 +754,17 @@ export class TaskExecutor {
       if (spinner)
         spinner.succeed(`Commit message generated: ${commitMessage}`);
 
-      if (!quiet) spinner = ora('Committing changes...').start();
-      if (!this.gitManager) {
-        throw new Error('GitManager not initialized');
-      }
+      const sessionId = await this.commitWithFixLoop(
+        commitMessage,
+        executionPath,
+        task.uuid,
+        quiet,
+        result.sessionId
+      );
 
-      // Try to commit, handling pre-commit hook failures
-      let commitAttempts = 0;
-      const maxCommitAttempts = 3;
-      let commitSucceeded = false;
-
-      while (commitAttempts < maxCommitAttempts && !commitSucceeded) {
-        try {
-          await this.gitManager.commitChanges(commitMessage);
-          // Only show success message if spinner is running (first attempt)
-          if (spinner) {
-            if (commitAttempts === 0) {
-              spinner.succeed('Changes committed');
-            } else if (spinner.isSpinning) {
-              spinner.succeed('Commit successful after retry');
-            }
-          }
-          commitSucceeded = true;
-        } catch (commitError) {
-          commitAttempts++;
-
-          const errorMessage =
-            commitError instanceof Error
-              ? commitError.message
-              : String(commitError);
-
-          // Check if this is a pre-commit hook failure
-          if (
-            errorMessage.includes('pre-commit') &&
-            commitAttempts < maxCommitAttempts
-          ) {
-            if (spinner) {
-              spinner.fail(
-                `Pre-commit hook failed (attempt ${commitAttempts}/${maxCommitAttempts})`
-              );
-              console.log(
-                chalk.yellow('🔧 Running Claude to fix pre-commit errors...')
-              );
-            }
-
-            // Extract the error details from the commit error
-            let errorDetails = errorMessage;
-
-            // Condense error details if they're too large (over 10,000 characters)
-            const MAX_ERROR_LENGTH = 10000;
-            if (errorDetails.length > MAX_ERROR_LENGTH) {
-              if (!quiet) {
-                console.log(
-                  chalk.yellow(
-                    `📊 Build output is large (${errorDetails.length} chars), condensing with AI...`
-                  )
-                );
-              }
-              try {
-                errorDetails =
-                  await this.getOpenAIService().condenseBuildOutput(
-                    errorDetails,
-                    MAX_ERROR_LENGTH
-                  );
-              } catch (condenseError) {
-                // If condensation fails, just use truncation
-                console.warn(
-                  chalk.yellow(
-                    'Failed to condense output, using truncation instead'
-                  ),
-                  condenseError
-                );
-              }
-            }
-
-            // Prepare prompt for Claude to fix the errors
-            const fixPrompt = `Fix the following pre-commit hook errors:\n\n${errorDetails}\n\nPlease fix all TypeScript errors, linting issues, and any other problems preventing the commit.`;
-
-            if (!quiet)
-              spinner = ora(
-                'Running Claude to fix pre-commit errors...'
-              ).start();
-
-            try {
-              // Run Claude to fix the errors
-              const fixResult = await this.getClaudeExecutor().executeTask(
-                fixPrompt,
-                worktreePath || this.workingDir
-              );
-              if (spinner)
-                spinner.succeed('Claude attempted to fix the errors');
-
-              // Update the execution log with the fix attempt
-              const previousLog = await this.jobManager.getTaskExecutionLog(
-                task.uuid
-              );
-              await this.jobManager.updateTaskExecutionLog(
-                task.uuid,
-                `${previousLog}\n\n--- Pre-commit Fix Attempt ${commitAttempts} ---\n${fixResult.log}`
-              );
-
-              // Try to commit again on the next iteration
-              if (!quiet) spinner = ora('Retrying commit...').start();
-            } catch (fixError) {
-              if (spinner) spinner.fail('Failed to run Claude to fix errors');
-              if (!quiet)
-                console.error(
-                  chalk.red('Claude fix attempt failed:'),
-                  fixError
-                );
-              throw commitError; // Re-throw the original error
-            }
-          } else {
-            // Not a pre-commit error or max attempts reached
-            throw commitError;
-          }
-        }
-      }
-
-      if (!commitSucceeded) {
-        throw new Error(
-          `Failed to commit after ${maxCommitAttempts} attempts due to pre-commit hook failures`
-        );
+      // Optionally self-review the branch before opening the PR
+      if (this.selfReviewEnabled) {
+        await this.runSelfReview(executionPath, task.uuid, quiet, sessionId);
       }
 
       if (!quiet) spinner = ora('Pushing branch...').start();
@@ -849,132 +948,13 @@ export class TaskExecutor {
           if (spinner)
             spinner.succeed(`Commit message generated: ${commitMessage}`);
 
-          if (!quiet) spinner = ora('Committing changes...').start();
-
-          // Try to commit, handling pre-commit hook failures
-          let commitAttempts = 0;
-          const maxCommitAttempts = 3;
-          let commitSucceeded = false;
-
-          while (commitAttempts < maxCommitAttempts && !commitSucceeded) {
-            try {
-              await this.gitManager.commitChanges(commitMessage);
-              // Only show success message if spinner is running (first attempt)
-              if (spinner) {
-                if (commitAttempts === 0) {
-                  spinner.succeed('Changes committed');
-                } else if (spinner.isSpinning) {
-                  spinner.succeed('Commit successful after retry');
-                }
-              }
-              commitSucceeded = true;
-            } catch (commitError) {
-              commitAttempts++;
-
-              const errorMessage =
-                commitError instanceof Error
-                  ? commitError.message
-                  : String(commitError);
-
-              // Check if this is a pre-commit hook failure
-              if (
-                errorMessage.includes('pre-commit') &&
-                commitAttempts < maxCommitAttempts
-              ) {
-                if (spinner) {
-                  spinner.fail(
-                    `Pre-commit hook failed (attempt ${commitAttempts}/${maxCommitAttempts})`
-                  );
-                  console.log(
-                    chalk.yellow(
-                      '🔧 Running Claude to fix pre-commit errors...'
-                    )
-                  );
-                }
-
-                // Extract the error details from the commit error
-                let errorDetails = errorMessage;
-
-                // Condense error details if they're too large (over 10,000 characters)
-                const MAX_ERROR_LENGTH = 10000;
-                if (errorDetails.length > MAX_ERROR_LENGTH) {
-                  if (!quiet) {
-                    console.log(
-                      chalk.yellow(
-                        `📊 Build output is large (${errorDetails.length} chars), condensing with AI...`
-                      )
-                    );
-                  }
-                  try {
-                    errorDetails =
-                      await this.getOpenAIService().condenseBuildOutput(
-                        errorDetails,
-                        MAX_ERROR_LENGTH
-                      );
-                  } catch (condenseError) {
-                    // If condensation fails, just use truncation
-                    console.warn(
-                      chalk.yellow(
-                        'Failed to condense output, using truncation instead'
-                      ),
-                      condenseError
-                    );
-                  }
-                }
-
-                // Prepare prompt for Claude to fix the errors
-                const fixPrompt = `Fix the following pre-commit hook errors:\n\n${errorDetails}\n\nPlease fix all TypeScript errors, linting issues, and any other problems preventing the commit.`;
-
-                if (!quiet)
-                  spinner = ora(
-                    'Running Claude to fix pre-commit errors...'
-                  ).start();
-
-                try {
-                  // Run Claude to fix the errors (pass session ID to maintain context)
-                  const fixResult = await this.getClaudeExecutor().executeTask(
-                    fixPrompt,
-                    executionPath,
-                    sessionId
-                  );
-                  // Update session ID
-                  sessionId = fixResult.sessionId;
-                  if (spinner)
-                    spinner.succeed('Claude attempted to fix the errors');
-
-                  // Update the execution log with the fix attempt
-                  const previousLog = await this.jobManager.getTaskExecutionLog(
-                    task.uuid
-                  );
-                  await this.jobManager.updateTaskExecutionLog(
-                    task.uuid,
-                    `${previousLog}\n\n--- Pre-commit Fix Attempt ${commitAttempts} ---\n${fixResult.log}`
-                  );
-
-                  // Try to commit again on the next iteration
-                  if (!quiet) spinner = ora('Retrying commit...').start();
-                } catch (fixError) {
-                  if (spinner)
-                    spinner.fail('Failed to run Claude to fix errors');
-                  if (!quiet)
-                    console.error(
-                      chalk.red('Claude fix attempt failed:'),
-                      fixError
-                    );
-                  throw commitError; // Re-throw the original error
-                }
-              } else {
-                // Not a pre-commit error or max attempts reached
-                throw commitError;
-              }
-            }
-          }
-
-          if (!commitSucceeded) {
-            throw new Error(
-              `Failed to commit after ${maxCommitAttempts} attempts due to pre-commit hook failures`
-            );
-          }
+          sessionId = await this.commitWithFixLoop(
+            commitMessage,
+            executionPath,
+            task.uuid,
+            quiet,
+            sessionId
+          );
         } else {
           if (!quiet)
             console.log(chalk.yellow('⚠️  No changes detected for this task'));
@@ -985,6 +965,16 @@ export class TaskExecutor {
           console.log(
             chalk.green(`✅ Task ${i + 1}/${tasks.length} completed`)
           );
+      }
+
+      // Optionally self-review the combined branch before opening the PR
+      if (this.selfReviewEnabled) {
+        sessionId = await this.runSelfReview(
+          worktreePath || this.workingDir,
+          tasks[tasks.length - 1].uuid,
+          quiet,
+          sessionId
+        );
       }
 
       // After all tasks are complete, create a single PR
@@ -1065,6 +1055,7 @@ export class TaskExecutor {
     try {
       this.baseBranch = config.baseBranch?.trim() || undefined;
       this.executionMode = config.mode || 'simple';
+      this.selfReviewEnabled = config.selfReview || false;
 
       // Quiet mode: suppress all intermediate output
       const executor = this.getClaudeExecutor();

--- a/src/services/task-executor.ts
+++ b/src/services/task-executor.ts
@@ -324,7 +324,8 @@ export class TaskExecutor {
   async executeWorkflow(
     rewritePrompt: boolean = false,
     baseBranch?: string,
-    mode: ExecutionMode = 'simple'
+    mode: ExecutionMode = 'simple',
+    selfReview: boolean = false
   ): Promise<void> {
     try {
       this.baseBranch = baseBranch?.trim() || undefined;
@@ -454,24 +455,26 @@ export class TaskExecutor {
         let shouldWaitForComments = false;
         const inquirer = (await import('inquirer')).default;
 
-        const { waitForComments, selfReview } = await inquirer.prompt([
-          {
-            type: 'confirm',
-            name: 'waitForComments',
-            message:
-              'After completing tasks, would you like to wait 30 minutes for PR reviews and automatically address any comments?',
-            default: false
-          },
-          {
-            type: 'confirm',
-            name: 'selfReview',
-            message:
-              'Would you like Claude to self-review its changes before opening each PR?',
-            default: false
-          }
-        ]);
+        const { waitForComments, selfReview: promptedSelfReview } =
+          await inquirer.prompt([
+            {
+              type: 'confirm',
+              name: 'waitForComments',
+              message:
+                'After completing tasks, would you like to wait 30 minutes for PR reviews and automatically address any comments?',
+              default: false
+            },
+            {
+              type: 'confirm',
+              name: 'selfReview',
+              message:
+                'Would you like Claude to self-review its changes before opening each PR?',
+              default: false,
+              when: !selfReview
+            }
+          ]);
         shouldWaitForComments = waitForComments;
-        this.selfReviewEnabled = selfReview;
+        this.selfReviewEnabled = selfReview || promptedSelfReview;
 
         // Optionally rewrite prompts before execution
         if (rewritePrompt) {
@@ -774,12 +777,19 @@ export class TaskExecutor {
       await this.gitManager.pushBranch(branchName);
       if (spinner) spinner.succeed('Branch pushed to origin');
 
+      // Recompute the diff/changed files against the base branch so the PR
+      // description reflects any commits self-review made after the initial commit.
+      const finalDiff = this.gitManager.getDiff(`origin/${targetBranch}`, 'HEAD');
+      const finalChangedFiles = this.gitManager.getChangedFiles(
+        `origin/${targetBranch}`
+      );
+
       if (!quiet) spinner = ora('Generating PR description...').start();
       const { title, body } =
         await this.getOpenAIService().generatePullRequestDescription(
           task.description,
-          diff,
-          changedFiles
+          finalDiff,
+          finalChangedFiles
         );
       if (spinner) spinner.succeed('PR description generated');
 

--- a/src/services/task-executor.ts
+++ b/src/services/task-executor.ts
@@ -325,11 +325,8 @@ export class TaskExecutor {
     rewritePrompt: boolean = false,
     baseBranch?: string,
     mode: ExecutionMode = 'simple',
-<<<<<<< Updated upstream
-    selfReview: boolean = false
-=======
+    selfReview: boolean = false,
     prefilledTasks?: string[]
->>>>>>> Stashed changes
   ): Promise<void> {
     try {
       this.baseBranch = baseBranch?.trim() || undefined;

--- a/src/types/non-interactive-config.ts
+++ b/src/types/non-interactive-config.ts
@@ -26,6 +26,13 @@ export interface NonInteractiveConfig {
   waitForComments?: boolean;
 
   /**
+   * Before opening a PR, run a Claude self-review pass over the branch's changes
+   * and commit any fixes it makes (going through the pre-commit fix loop again if needed)
+   * Default: false
+   */
+  selfReview?: boolean;
+
+  /**
    * Optional: Repository path to execute tasks in
    * Defaults to current working directory
    */


### PR DESCRIPTION
## Summary
- Adds a `--self-review` CLI flag / `selfReview` config option that has Claude review its own changes and commit any fixes before a PR is opened, reusing the existing pre-commit fix-retry loop.
- Fixes two bugs found during self-review of this branch:
  - The single-task PR path built its PR description from a diff snapshot taken *before* the self-review pass ran, so self-review commits were missing from the PR body. Now recomputed against the base branch after push (matching the combined-PR path).
  - `--self-review` was parsed but silently dropped in the fully-interactive (no task argument) CLI path — it now threads through to `executeWorkflow`.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] `npm test` — currently broken on `main` too (missing `jest.config.cjs`), unrelated to this change
- [x] Multi-agent self-review of the diff (8 finder angles + verification) surfaced and fixed the two bugs above; remaining lower-severity cleanup items (duplicated self-review call sites, redundant git staging in the self-review commit path, log attribution for combined-PR self-review) are left as follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional self-review step that uses Claude to review branch changes before opening a pull request.
  * Self-review can be enabled with the `--self-review` CLI option or the `selfReview` configuration setting.
  * Automatically commits applicable review fixes and updates pull request details to reflect those changes.
* **Documentation**
  * Updated the CLI reference and example configuration with the new self-review option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->